### PR TITLE
Feat: add tag-std and cargo-tag-std demo by driving rustc

### DIFF
--- a/demo/rustc_driver/Cargo.toml
+++ b/demo/rustc_driver/Cargo.toml
@@ -10,5 +10,4 @@ path = "src/bin/cargo_tag_std.rs"
 [dependencies]
 
 [package.metadata.rust-analyzer]
-# nightly-2025-04-21-x86_64-unknown-linux-gnu
 rustc_private = true

--- a/demo/rustc_driver/Cargo.toml
+++ b/demo/rustc_driver/Cargo.toml
@@ -3,6 +3,10 @@ name = "tag-std"
 version = "0.1.0"
 edition = "2024"
 
+[[bin]]
+name = "cargo-tag-std"
+path = "src/bin/cargo_tag_std.rs"
+
 [dependencies]
 
 [package.metadata.rust-analyzer]

--- a/demo/rustc_driver/Cargo.toml
+++ b/demo/rustc_driver/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "tag-std"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[package.metadata.rust-analyzer]
+# nightly-2025-04-21-x86_64-unknown-linux-gnu
+rustc_private = true

--- a/demo/rustc_driver/run.sh
+++ b/demo/rustc_driver/run.sh
@@ -4,8 +4,18 @@ set -ex
 export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 
 cargo build
-tag_std=$PWD/target/debug/tag-std
+export TAG_STD=$PWD/target/debug/tag-std
+export CARGO_TAG_STD=$PWD/target/debug/cargo_tag_std
+export TAG_STD_CROSS_CRATES=true
+export CARGO_TERM_VERBOSE=true
 
 # Test basic demo
 cd ./tests/basic
-$tag_std src/lib.rs --crate-type=lib
+
+cargo b
+
+# Analyze the lib crate.
+# $tag_std src/lib.rs --crate-type=lib
+
+# Analyze the bin crate.
+$CARGO_TAG_STD

--- a/demo/rustc_driver/run.sh
+++ b/demo/rustc_driver/run.sh
@@ -1,0 +1,11 @@
+set -ex
+
+# Set up toolchain: works under current folder.
+export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
+
+cargo build
+tag_std=$PWD/target/debug/tag-std
+
+# Test basic demo
+cd ./tests/basic
+$tag_std src/lib.rs --crate-type=lib

--- a/demo/rustc_driver/run.sh
+++ b/demo/rustc_driver/run.sh
@@ -6,13 +6,12 @@ export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 cargo build
 export TAG_STD=$PWD/target/debug/tag-std
 export CARGO_TAG_STD=$PWD/target/debug/cargo_tag_std
-export TAG_STD_CROSS_CRATES=true
-export CARGO_TERM_VERBOSE=true
+# export CARGO_TERM_VERBOSE=true
 
 # Test basic demo
 cd ./tests/basic
 
-cargo b
+cargo clean
 
 # Analyze the lib crate.
 # $tag_std src/lib.rs --crate-type=lib

--- a/demo/rustc_driver/run.sh
+++ b/demo/rustc_driver/run.sh
@@ -5,7 +5,7 @@ export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 
 cargo build
 export TAG_STD=$PWD/target/debug/tag-std
-export CARGO_TAG_STD=$PWD/target/debug/cargo_tag_std
+export CARGO_TAG_STD=$PWD/target/debug/cargo-tag-std
 # export CARGO_TERM_VERBOSE=true
 
 # Test basic demo

--- a/demo/rustc_driver/run.sh
+++ b/demo/rustc_driver/run.sh
@@ -6,15 +6,12 @@ export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 cargo build
 export TAG_STD=$PWD/target/debug/tag-std
 export CARGO_TAG_STD=$PWD/target/debug/cargo-tag-std
-# export CARGO_TERM_VERBOSE=true
 
 # Test basic demo
 cd ./tests/basic
 
 cargo clean
 
-# Analyze the lib crate.
-# $tag_std src/lib.rs --crate-type=lib
-
-# Analyze the bin crate.
+# Analyze the lib and bin crates.
+# Same as `cargo tag-std` when tag-std and cargo-tag-std are installed.
 $CARGO_TAG_STD

--- a/demo/rustc_driver/rust-toolchain.toml
+++ b/demo/rustc_driver/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-05-08"
+components = ["llvm-tools", "rustc-dev", "rust-src", "rust-analyzer"]

--- a/demo/rustc_driver/rustfmt.toml
+++ b/demo/rustc_driver/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+style_edition = "2024"
+use_small_heuristics = "Max"
+merge_derives = false

--- a/demo/rustc_driver/src/bin/cargo_tag_std.rs
+++ b/demo/rustc_driver/src/bin/cargo_tag_std.rs
@@ -1,0 +1,42 @@
+use std::{env::var, process::Command};
+
+fn main() {
+    let cargo_tag_std = var("CARGO_TAG_STD").unwrap();
+    let tag_std = var("TAG_STD").unwrap();
+
+    let mut args = std::env::args().collect::<Vec<_>>();
+
+    if args.len() == 2 && args[1].as_str() == "-vV" {
+        // cargo invokes `rustc -vV` first
+        run("rustc", &["-vV".to_owned()], &[]);
+    } else if std::env::var("WRAPPER").as_deref() == Ok("1") {
+        // then cargo invokes `rustc - --crate-name ___ --print=file-names`
+        if args[1] == "-" {
+            // `rustc -` is a substitute file name from stdin
+            args[1] = "src/lib.rs".to_owned();
+        }
+
+        run(&tag_std, &args[1..], &[]);
+    } else {
+        run(
+            "cargo",
+            &["build", "-vvv"].map(String::from),
+            &[("RUSTC", &cargo_tag_std), ("WRAPPER", "1")],
+        );
+    }
+}
+
+fn run(cmd: &str, args: &[String], vars: &[(&str, &str)]) {
+    let status = Command::new(cmd)
+        .args(args)
+        .envs(vars.iter().copied())
+        .stdout(std::io::stdout())
+        .stderr(std::io::stderr())
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+    if !status.success() {
+        eprintln!("[error] {cmd}: args={args:?} vars={vars:?}");
+    }
+}

--- a/demo/rustc_driver/src/bin/cargo_tag_std.rs
+++ b/demo/rustc_driver/src/bin/cargo_tag_std.rs
@@ -18,11 +18,7 @@ fn main() {
 
         run(&tag_std, &args[1..], &[]);
     } else {
-        run(
-            "cargo",
-            &["build", "-vvv"].map(String::from),
-            &[("RUSTC", &cargo_tag_std), ("WRAPPER", "1")],
-        );
+        run("cargo", &["build"].map(String::from), &[("RUSTC", &cargo_tag_std), ("WRAPPER", "1")]);
     }
 }
 

--- a/demo/rustc_driver/src/bin/cargo_tag_std.rs
+++ b/demo/rustc_driver/src/bin/cargo_tag_std.rs
@@ -1,8 +1,10 @@
 use std::{env::var, process::Command};
 
 fn main() {
-    let cargo_tag_std = var("CARGO_TAG_STD").unwrap();
-    let tag_std = var("TAG_STD").unwrap();
+    // Search cargo-tag-std and tag-std CLI through environment variables,
+    // or just use the name if absent.
+    let cargo_tag_std = var("CARGO_TAG_STD").unwrap_or_else(|_| "cargo-tag-std".to_owned());
+    let tag_std = var("TAG_STD").unwrap_or_else(|_| "tag-std".to_owned());
 
     let mut args = std::env::args().collect::<Vec<_>>();
 

--- a/demo/rustc_driver/src/main.rs
+++ b/demo/rustc_driver/src/main.rs
@@ -1,0 +1,49 @@
+#![feature(rustc_private)]
+
+extern crate rustc_driver;
+extern crate rustc_interface;
+extern crate rustc_middle;
+#[macro_use]
+extern crate rustc_smir;
+extern crate stable_mir;
+
+use rustc_middle::ty::TyCtxt;
+use stable_mir::{CrateDef, ItemKind, mir::mono::Instance};
+
+fn main() {
+    let rustc_args: Vec<_> = std::env::args().collect();
+    _ = run_with_tcx!(&rustc_args, |tcx| {
+        analyze(tcx);
+
+        // Don't emit real artifacts.
+        ControlFlow::<(), ()>::Break(())
+    });
+}
+
+const REGISTER_TOOL_ATTR: &str = "#[tag_std";
+
+fn analyze(tcx: TyCtxt) {
+    let local_items = stable_mir::all_local_items();
+    let functions = local_items.iter().filter(|item| matches!(item.kind(), ItemKind::Fn));
+
+    for fun in functions {
+        let instance = match Instance::try_from(*fun) {
+            Ok(instance) => instance,
+            Err(err) => {
+                eprintln!("Failed to get the instance for {fun:?}:\n{err:?}");
+                continue;
+            }
+        };
+        let tool_attrs = fun
+            .all_tool_attrs()
+            .into_iter()
+            .filter(|attr| attr.as_str().starts_with(REGISTER_TOOL_ATTR));
+        for tag_attr in tool_attrs {
+            println!(
+                "[{fn_name:?}] {attrs:?}\n",
+                fn_name = instance.name(),
+                attrs = tag_attr.as_str()
+            );
+        }
+    }
+}

--- a/demo/rustc_driver/src/main.rs
+++ b/demo/rustc_driver/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private)]
 
+extern crate rustc_data_structures;
 extern crate rustc_driver;
 extern crate rustc_interface;
 extern crate rustc_middle;
@@ -7,13 +8,17 @@ extern crate rustc_middle;
 extern crate rustc_smir;
 extern crate stable_mir;
 
-use rustc_middle::ty::TyCtxt;
-use stable_mir::{CrateDef, ItemKind, mir::mono::Instance};
+use rustc_data_structures::fx::FxHashSet;
+use stable_mir::{
+    CrateDef, CrateItem, ItemKind,
+    mir::{MirVisitor, mono::Instance, visit::Location},
+    ty::Ty,
+};
 
 fn main() {
     let rustc_args: Vec<_> = std::env::args().collect();
-    _ = run_with_tcx!(&rustc_args, |tcx| {
-        analyze(tcx);
+    _ = run!(&rustc_args, || {
+        analyze();
 
         // Don't emit real artifacts.
         ControlFlow::<(), ()>::Break(())
@@ -22,7 +27,8 @@ fn main() {
 
 const REGISTER_TOOL_ATTR: &str = "#[tag_std";
 
-fn analyze(tcx: TyCtxt) {
+fn analyze() {
+    let mut reachability = Reachability::new();
     let local_items = stable_mir::all_local_items();
     let functions = local_items.iter().filter(|item| matches!(item.kind(), ItemKind::Fn));
 
@@ -34,16 +40,75 @@ fn analyze(tcx: TyCtxt) {
                 continue;
             }
         };
-        let tool_attrs = fun
-            .all_tool_attrs()
-            .into_iter()
-            .filter(|attr| attr.as_str().starts_with(REGISTER_TOOL_ATTR));
-        for tag_attr in tool_attrs {
-            println!(
-                "[{fn_name:?}] {attrs:?}\n",
-                fn_name = instance.name(),
-                attrs = tag_attr.as_str()
-            );
+
+        reachability.add_instance(instance);
+    }
+
+    dbg!(reachability.instances.len(), reachability.cross_crates);
+    reachability.print_tag_std_attrs();
+}
+
+#[derive(Debug, Default)]
+struct Reachability {
+    /// Collect monomorphized instances.
+    instances: FxHashSet<Instance>,
+    /// Enable this to collect instances from dependencies.
+    #[allow(dead_code)]
+    cross_crates: bool,
+}
+
+impl Reachability {
+    fn new() -> Self {
+        Self {
+            cross_crates: std::env::var("TAG_STD_CROSS_CRATES")
+                .map(|var| var == "true")
+                .unwrap_or(false),
+            ..Default::default()
+        }
+    }
+
+    fn add_instance(&mut self, instance: Instance) {
+        if self.instances.insert(instance) {
+            // recurse if this is the first time of insertion
+            if let Some(body) = instance.body() {
+                println!("(body) {:?}", instance.name());
+                self.visit_body(&body);
+            }
+        }
+    }
+
+    fn print_tag_std_attrs(&self) {
+        // let mut file = std::fs::File::create("tag-std.txt").unwrap();
+        for instance in &self.instances {
+            // Only user defined instances can be converted.
+            match CrateItem::try_from(*instance) {
+                Ok(item) => {
+                    let tool_attrs = item
+                        .all_tool_attrs()
+                        .into_iter()
+                        .filter(|attr| attr.as_str().starts_with(REGISTER_TOOL_ATTR));
+                    for tag_attr in tool_attrs {
+                        println!(
+                            "[{fn_name:?}] {attrs:?}\n",
+                            fn_name = instance.name(),
+                            attrs = tag_attr.as_str()
+                        );
+                    }
+                }
+                Err(err) => {
+                    println!("(error) {} not converted to be an item: {err:?}", instance.name())
+                }
+            }
+        }
+    }
+}
+
+impl MirVisitor for Reachability {
+    fn visit_ty(&mut self, ty: &Ty, _: Location) {
+        if let Some((fn_def, args)) = ty.kind().fn_def() {
+            // Add an instance.
+            let instance = Instance::resolve(fn_def, args).unwrap();
+            self.add_instance(instance);
         }
     }
 }

--- a/demo/rustc_driver/src/main.rs
+++ b/demo/rustc_driver/src/main.rs
@@ -2,6 +2,8 @@
 
 extern crate rustc_data_structures;
 extern crate rustc_driver;
+extern crate rustc_hir;
+extern crate rustc_hir_pretty;
 extern crate rustc_interface;
 extern crate rustc_middle;
 #[macro_use]
@@ -9,6 +11,9 @@ extern crate rustc_smir;
 extern crate stable_mir;
 
 use rustc_data_structures::fx::FxHashSet;
+use rustc_hir::Attribute;
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::rustc_internal::internal;
 use stable_mir::{
     CrateDef, CrateItem, ItemKind,
     mir::{MirVisitor, mono::Instance, visit::Location},
@@ -17,18 +22,19 @@ use stable_mir::{
 
 fn main() {
     let rustc_args: Vec<_> = std::env::args().collect();
-    _ = run!(&rustc_args, || {
-        analyze();
+    _ = run_with_tcx!(&rustc_args, |tcx| {
+        analyze(tcx);
 
         // Don't emit real artifacts.
-        ControlFlow::<(), ()>::Break(())
+        ControlFlow::<(), ()>::Continue(())
     });
 }
 
 const REGISTER_TOOL_ATTR: &str = "#[tag_std";
+const TAG_STD: &str = "tag_std";
 
-fn analyze() {
-    let mut reachability = Reachability::new();
+fn analyze(tcx: TyCtxt) {
+    let mut reachability = Reachability::default();
     let local_items = stable_mir::all_local_items();
     let functions = local_items.iter().filter(|item| matches!(item.kind(), ItemKind::Fn));
 
@@ -44,62 +50,75 @@ fn analyze() {
         reachability.add_instance(instance);
     }
 
-    dbg!(reachability.instances.len(), reachability.cross_crates);
-    reachability.print_tag_std_attrs();
+    dbg!(reachability.instances.len());
+    reachability.print_tag_std_attrs(tcx);
 }
 
 #[derive(Debug, Default)]
 struct Reachability {
     /// Collect monomorphized instances.
     instances: FxHashSet<Instance>,
-    /// Enable this to collect instances from dependencies.
-    #[allow(dead_code)]
-    cross_crates: bool,
 }
 
 impl Reachability {
-    fn new() -> Self {
-        Self {
-            cross_crates: std::env::var("TAG_STD_CROSS_CRATES")
-                .map(|var| var == "true")
-                .unwrap_or(false),
-            ..Default::default()
-        }
-    }
-
     fn add_instance(&mut self, instance: Instance) {
         if self.instances.insert(instance) {
             // recurse if this is the first time of insertion
             if let Some(body) = instance.body() {
-                println!("(body) {:?}", instance.name());
+                // println!("(body) {:?}", instance.name());
                 self.visit_body(&body);
             }
         }
     }
 
-    fn print_tag_std_attrs(&self) {
+    fn print_tag_std_attrs(&self, tcx: TyCtxt) {
         // let mut file = std::fs::File::create("tag-std.txt").unwrap();
         for instance in &self.instances {
             // Only user defined instances can be converted.
             match CrateItem::try_from(*instance) {
-                Ok(item) => {
-                    let tool_attrs = item
-                        .all_tool_attrs()
-                        .into_iter()
-                        .filter(|attr| attr.as_str().starts_with(REGISTER_TOOL_ATTR));
-                    for tag_attr in tool_attrs {
-                        println!(
-                            "[{fn_name:?}] {attrs:?}\n",
-                            fn_name = instance.name(),
-                            attrs = tag_attr.as_str()
-                        );
-                    }
-                }
-                Err(err) => {
-                    println!("(error) {} not converted to be an item: {err:?}", instance.name())
+                Ok(item) => print_tag_std_attrs(instance, item),
+                Err(_) => {
+                    // println!("(error) {} not converted to be an item: {err:?}", instance.name());
+                    // Resort to internal API for unsupported StableMir conversions.
+                    print_tag_std_attrs_throgh_internal_apis(tcx, instance);
                 }
             }
         }
+    }
+}
+
+fn print_tag_std_attrs_throgh_internal_apis(tcx: TyCtxt<'_>, instance: &Instance) {
+    let def_id = internal(tcx, instance.def.def_id());
+    let tool_attrs = tcx.get_all_attrs(def_id).filter(|attr| {
+        if let Attribute::Unparsed(tool_attr) = attr {
+            if tool_attr.path.segments[0].as_str() == TAG_STD {
+                return true;
+            }
+        }
+        false
+    });
+    for attr in tool_attrs {
+        println!(
+            "\n(internal api) {fn_name:?} ({span:?}) => {attr:?}",
+            fn_name = instance.name(),
+            span = instance.def.span().diagnostic(),
+            attr = rustc_hir_pretty::attribute_to_string(&tcx, attr)
+        );
+    }
+}
+
+fn print_tag_std_attrs(instance: &Instance, item: CrateItem) {
+    let tool_attrs = item
+        .all_tool_attrs()
+        .into_iter()
+        .filter(|attr| attr.as_str().starts_with(REGISTER_TOOL_ATTR));
+    for tag_attr in tool_attrs {
+        println!(
+            "\n(stable mir) {fn_name:?} ({span:?}) => {attr:?}",
+            fn_name = instance.name(),
+            span = instance.def.span().diagnostic(),
+            attr = tag_attr.as_str()
+        );
     }
 }
 

--- a/demo/rustc_driver/tests/basic/Cargo.toml
+++ b/demo/rustc_driver/tests/basic/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "demo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/demo/rustc_driver/tests/basic/src/lib.rs
+++ b/demo/rustc_driver/tests/basic/src/lib.rs
@@ -1,0 +1,30 @@
+#![feature(register_tool)]
+#![register_tool(tag_std)]
+
+use std::slice;
+
+// #[tag_std(!Reachable())]
+#[tag_std::unreachable]
+pub unsafe fn test() {
+    println!("unreachable!");
+}
+
+pub struct MyStruct {
+    ptr: *mut u8,
+    len: usize,
+}
+impl MyStruct {
+    pub fn from(p: *mut u8, l: usize) -> MyStruct {
+        MyStruct { ptr: p, len: l }
+    }
+    ///contract(!Null(self.ptr); Align(self.ptr, u8); Allocated(self.ptr, u8, self.len, *); Init(self.ptr, u8, self.len, *); ValidInt(self.len*sizeof(u8), [0,isize::MAX]); Alias(self.ptr, *);
+    #[tag_std::contract(
+        !Null(self.ptr) && Align(self.ptr, u8) &&
+        Allocated(self.ptr, u8, self.len, *) && Init(self.ptr, u8, self.len, *) &&
+        ValidInt(self.len*sizeof(u8), [0,isize::MAX]) && Alias(self.ptr, *)
+    )]
+    #[allow(clippy::mut_from_ref)]
+    pub unsafe fn get(&self) -> &mut [u8] {
+        unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}

--- a/demo/rustc_driver/tests/basic/src/lib.rs
+++ b/demo/rustc_driver/tests/basic/src/lib.rs
@@ -3,7 +3,6 @@
 
 use std::slice;
 
-// #[tag_std(!Reachable())]
 #[tag_std::unreachable]
 pub unsafe fn test() {
     println!("unreachable!");

--- a/demo/rustc_driver/tests/basic/src/main.rs
+++ b/demo/rustc_driver/tests/basic/src/main.rs
@@ -3,6 +3,8 @@
 #![feature(register_tool)]
 #![register_tool(tag_std)]
 
+extern crate demo;
+
 use demo::MyStruct;
 
 fn main() {

--- a/demo/rustc_driver/tests/basic/src/main.rs
+++ b/demo/rustc_driver/tests/basic/src/main.rs
@@ -1,0 +1,12 @@
+#![feature(vec_into_raw_parts)]
+#![allow(unused_variables)]
+#![feature(register_tool)]
+#![register_tool(tag_std)]
+
+use demo::MyStruct;
+
+fn main() {
+    let (p, l, _c) = Vec::new().into_raw_parts();
+    let a = MyStruct::from(p, l);
+    println!("{:?}", unsafe { a.get() });
+}

--- a/demo/rustc_driver/tests/basic/src/main.rs
+++ b/demo/rustc_driver/tests/basic/src/main.rs
@@ -1,9 +1,5 @@
 #![feature(vec_into_raw_parts)]
 #![allow(unused_variables)]
-#![feature(register_tool)]
-#![register_tool(tag_std)]
-
-// extern crate demo;
 
 use demo::MyStruct;
 

--- a/demo/rustc_driver/tests/basic/src/main.rs
+++ b/demo/rustc_driver/tests/basic/src/main.rs
@@ -3,7 +3,7 @@
 #![feature(register_tool)]
 #![register_tool(tag_std)]
 
-extern crate demo;
+// extern crate demo;
 
 use demo::MyStruct;
 


### PR DESCRIPTION
```rust
********* "demo" [Rlib] has reached 10 instances *********
(stable mir) "test" ("src/lib.rs:8:1: 8:21") => "#[tag_std::unreachable]\n"

(stable mir) "MyStruct::get" ("src/lib.rs:27:5: 27:42") => "#[tag_std::contract(!Null(self.ptr) && Align(self.ptr, u8) &&\nAllocated(self.ptr, u8, self.len, *) && Init(self.ptr, u8, self.len, *) &&\nValidInt(self.len*sizeof(u8), [0,isize::MAX]) && Alias(self.ptr, *))]\n"

********* "demo" [Executable] has reached 18 instances *********
(internal api) "demo::MyStruct::get" ("/home/zjp/rust/tag-std/demo/rustc_driver/tests/basic/src/lib.rs:27:5: 27:42") => "#[tag_std::contract(!Null(self.ptr) && Align(self.ptr, u8) &&\nAllocated(self.ptr, u8, self.len, *) && Init(self.ptr, u8, self.len, *) &&\nValidInt(self.len*sizeof(u8), [0,isize::MAX]) && Alias(self.ptr, *))]\n"
```

![image](https://github.com/user-attachments/assets/2f224988-e527-4968-84fb-445024aebe4e)

