### PR TITLE
Feat: implement `#[precond]` `#[hazard]` and `#[option]` proc-macros

### DIFF
--- a/demo/rustc_driver/Cargo.toml
+++ b/demo/rustc_driver/Cargo.toml
@@ -9,5 +9,9 @@ path = "src/bin/cargo-safe-tool.rs"
 
 [dependencies]
 
+[workspace]
+members = [ "safety-tool-lib","safety-tool-macro", "safety-tool-parser"]
+exclude = ["tests/basic"]
+
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/demo/rustc_driver/Cargo.toml
+++ b/demo/rustc_driver/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/bin/cargo-safe-tool.rs"
 [dependencies]
 
 [workspace]
-members = [ "safety-tool-lib","safety-tool-macro", "safety-tool-parser"]
+members = ["safety-tool-lib","safety-tool-macro", "safety-tool-parser"]
 exclude = ["tests/basic"]
 
 [package.metadata.rust-analyzer]

--- a/demo/rustc_driver/run.sh
+++ b/demo/rustc_driver/run.sh
@@ -4,8 +4,8 @@ set -ex
 export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 
 cargo build
-export TAG_STD=$PWD/target/debug/safe-tool
-export CARGO_TAG_STD=$PWD/target/debug/cargo-safe-tool
+export SAFE_TOOL=$PWD/target/debug/safe-tool
+export CARGO_SAFE_TOOL=$PWD/target/debug/cargo-safe-tool
 
 # Test basic demo
 cd ./tests/basic
@@ -13,5 +13,5 @@ cd ./tests/basic
 cargo clean
 
 # Analyze the lib and bin crates.
-# Same as `cargo tag-std` when tag-std and cargo-tag-std are installed.
-$CARGO_TAG_STD
+# Same as `cargo safe-tool` when tag-std and cargo-safe-tool are installed.
+$CARGO_SAFE_TOOL

--- a/demo/rustc_driver/safety-tool-lib/Cargo.toml
+++ b/demo/rustc_driver/safety-tool-lib/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 safety-tool-macro = { path = "../safety-tool-macro" }
+safety-tool-parser = { path = "../safety-tool-parser" }

--- a/demo/rustc_driver/safety-tool-lib/Cargo.toml
+++ b/demo/rustc_driver/safety-tool-lib/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "safety-tool-lib"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+safety-tool-macro = { path = "../safety-tool-macro" }

--- a/demo/rustc_driver/safety-tool-lib/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-lib/src/lib.rs
@@ -1,0 +1,1 @@
+pub use safety_tool_macro::safety;

--- a/demo/rustc_driver/safety-tool-lib/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-lib/src/lib.rs
@@ -1,1 +1,5 @@
-pub use safety_tool_macro::safety;
+pub use safety_tool_parser;
+
+pub mod safety {
+    pub use safety_tool_macro::{hazard, option, precond};
+}

--- a/demo/rustc_driver/safety-tool-macro/Cargo.toml
+++ b/demo/rustc_driver/safety-tool-macro/Cargo.toml
@@ -8,3 +8,6 @@ proc-macro = true
 
 [dependencies]
 safety-tool-parser = { path = "../safety-tool-parser" }
+
+[dev-dependencies]
+expect-test = "1.5.1"

--- a/demo/rustc_driver/safety-tool-macro/Cargo.toml
+++ b/demo/rustc_driver/safety-tool-macro/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "safety-tool-macro"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+safety-tool-parser = { path = "../safety-tool-parser" }

--- a/demo/rustc_driver/safety-tool-macro/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-macro/src/lib.rs
@@ -1,0 +1,9 @@
+use proc_macro::TokenStream;
+use safety_tool_parser::{precond::SafetyAttrArgs, syn::*};
+
+#[proc_macro_attribute]
+pub fn safety(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr as SafetyAttrArgs);
+    dbg!(&attr);
+    item
+}

--- a/demo/rustc_driver/safety-tool-macro/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-macro/src/lib.rs
@@ -1,9 +1,17 @@
 use proc_macro::TokenStream;
-use safety_tool_parser::{precond::SafetyAttrArgs, syn::*};
+use safety_tool_parser::{
+    precond::{FnItem, SafetyAttrArgs},
+    syn::*,
+};
 
 #[proc_macro_attribute]
 pub fn safety(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
     let attr = parse_macro_input!(attr as SafetyAttrArgs);
+
     let gen_code = attr.generate_code();
-    gen_code.into_iter().map(TokenStream::from).chain([item]).collect()
+
+    let mut fn_item = FnItem::new(item);
+    fn_item.insert_doc_string_to_the_back(gen_code);
+    fn_item.into_token_stream().into()
 }

--- a/demo/rustc_driver/safety-tool-macro/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-macro/src/lib.rs
@@ -6,26 +6,28 @@ use safety_tool_parser::{
 
 #[proc_macro_attribute]
 pub fn precond(attr: TokenStream, item: TokenStream) -> TokenStream {
-    generate(attr, item)
+    generate("precond", attr, item)
 }
 
 #[proc_macro_attribute]
 pub fn hazard(attr: TokenStream, item: TokenStream) -> TokenStream {
-    generate(attr, item)
+    generate("hazard", attr, item)
 }
 
 #[proc_macro_attribute]
 pub fn option(attr: TokenStream, item: TokenStream) -> TokenStream {
-    generate(attr, item)
+    generate("option", attr, item)
 }
 
-fn generate(attr: TokenStream, item: TokenStream) -> TokenStream {
+fn generate(kind: &str, attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let attr = parse_macro_input!(attr as SafetyAttrArgs);
 
-    let gen_code = attr.generate_doc_comments();
+    let doc_comments = attr.generate_doc_comments();
+    let safety_tool_attr = attr.generate_safety_tool_attribute(kind);
 
     let mut fn_item = FnItem::new(item);
-    fn_item.insert_doc_comments_to_the_back(gen_code);
+    fn_item.insert_attributes_to_the_back(doc_comments);
+    fn_item.insert_attributes_to_the_back(safety_tool_attr);
     fn_item.into_token_stream().into()
 }

--- a/demo/rustc_driver/safety-tool-macro/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-macro/src/lib.rs
@@ -23,9 +23,9 @@ fn generate(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let attr = parse_macro_input!(attr as SafetyAttrArgs);
 
-    let gen_code = attr.generate_code();
+    let gen_code = attr.generate_doc_comments();
 
     let mut fn_item = FnItem::new(item);
-    fn_item.insert_doc_string_to_the_back(gen_code);
+    fn_item.insert_doc_comments_to_the_back(gen_code);
     fn_item.into_token_stream().into()
 }

--- a/demo/rustc_driver/safety-tool-macro/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-macro/src/lib.rs
@@ -4,6 +4,6 @@ use safety_tool_parser::{precond::SafetyAttrArgs, syn::*};
 #[proc_macro_attribute]
 pub fn safety(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr as SafetyAttrArgs);
-    dbg!(&attr);
-    item
+    let gen_code = attr.generate_code();
+    gen_code.into_iter().map(TokenStream::from).chain([item]).collect()
 }

--- a/demo/rustc_driver/safety-tool-macro/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-macro/src/lib.rs
@@ -5,7 +5,21 @@ use safety_tool_parser::{
 };
 
 #[proc_macro_attribute]
-pub fn safety(attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn precond(attr: TokenStream, item: TokenStream) -> TokenStream {
+    generate(attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn hazard(attr: TokenStream, item: TokenStream) -> TokenStream {
+    generate(attr, item)
+}
+
+#[proc_macro_attribute]
+pub fn option(attr: TokenStream, item: TokenStream) -> TokenStream {
+    generate(attr, item)
+}
+
+fn generate(attr: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
     let attr = parse_macro_input!(attr as SafetyAttrArgs);
 

--- a/demo/rustc_driver/safety-tool-macro/tests/memo.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo.rs
@@ -1,0 +1,8 @@
+use std::process::Command;
+
+#[test]
+fn basic() {
+    let stdout = Command::new("cargo-expand").args(["--test", "memo_testcase"]).output().unwrap();
+    let expanded = std::str::from_utf8(&stdout.stdout).unwrap();
+    println!("{expanded}");
+}

--- a/demo/rustc_driver/safety-tool-macro/tests/memo.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo.rs
@@ -1,8 +1,10 @@
+use expect_test::expect_file;
 use std::process::Command;
 
 #[test]
 fn basic() {
-    let stdout = Command::new("cargo-expand").args(["--test", "memo_testcase"]).output().unwrap();
+    let stdout =
+        Command::new("cargo").args(["expand", "--test", "memo_testcase"]).output().unwrap();
     let expanded = std::str::from_utf8(&stdout.stdout).unwrap();
-    println!("{expanded}");
+    expect_file!["snapshots/memo_testcase.rs"].assert_eq(expanded);
 }

--- a/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
@@ -23,3 +23,14 @@ fn multi_lines2() {}
 )]
 #[doc = " Line 3."]
 fn multi_lines3() {}
+
+/// Line 1.
+#[safety(Property, memo = "Line 2.\nLine 3.")]
+#[doc = " Line 4."]
+fn multi_lines4() {}
+
+/// Line 1.
+#[safety(Property, memo = "Line 2.\nLine 3.")]
+#[safety(Property, memo = "Line 4.")]
+#[doc = " Line 5."]
+fn multi_lines5() {}

--- a/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+use safety_tool_macro::safety;
+
+#[safety(Property, memo = "This is a single line.")]
+fn single_line() {}
+
+#[safety(Property, memo = "Line 1.\nLine 2.")]
+fn multi_lines() {}
+
+#[safety(
+    Property,
+    memo = "
+Line 1.
+Line 2."
+)]
+fn multi_lines2() {}
+
+#[safety(
+    Property,
+    memo = "
+    Line 1.
+    Line 2."
+)]
+#[doc = " Line 3."]
+fn multi_lines3() {}

--- a/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case)]
-use safety_tool_macro::safety;
+use safety_tool_macro as safety;
 
-#[safety(Property, memo = "This is a single line.")]
+#[safety::precond(Property, memo = "This is a single line.")]
 fn single_line() {}
 
-#[safety(Property, memo = "Line 1.\nLine 2.")]
+#[safety::hazard(Property, memo = "Line 1.\nLine 2.")]
 fn multi_lines() {}
 
-#[safety(
+#[safety::option(
     Property,
     memo = "
 Line 1.
@@ -15,8 +15,8 @@ Line 2."
 )]
 fn multi_lines2() {}
 
-#[doc = " Line 1."]
-#[safety(
+/// Line 1.
+#[safety::precond(
     Property,
     memo = "
     Line 2.
@@ -25,19 +25,19 @@ fn multi_lines2() {}
 fn multi_lines3() {}
 
 #[doc = " Line 1."]
-#[safety(
+#[safety::hazard(
     Property,
     memo = "
     Line 2.
     Line 3."
 )]
-#[safety(Property, memo = "Line 4.")]
+#[safety::option(Property, memo = "Line 4.")]
 fn multi_lines4() {}
 
 //  WARNING: dont't put `#[doc]` (i.e. `///`) after `#[safety(memo)]`
 // because the doc order will be messed up.
 
-#[safety(
+#[safety::precond(
     Property,
     memo = "
     Line 1.
@@ -47,12 +47,12 @@ fn multi_lines4() {}
 fn multi_lines3_DONT_DO_THIS() {}
 
 /// Line 1.
-#[safety(Property, memo = "Line 2.\nLine 3.")]
+#[safety::precond(Property, memo = "Line 2.\nLine 3.")]
 #[doc = " Line 4."] // don't do this.
 fn multi_lines4_DONT_DO_THIS() {}
 
 /// Line 1.
-#[safety(Property, memo = "Line 2.\nLine 3.")]
-#[safety(Property, memo = "Line 4.")]
+#[safety::precond(Property, memo = "Line 2.\nLine 3.")]
+#[safety::precond(Property, memo = "Line 4.")]
 #[doc = " Line 5."] // don't do this.
 fn multi_lines5_DONT_DO_THIS() {}

--- a/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, non_snake_case)]
 use safety_tool_macro::safety;
 
 #[safety(Property, memo = "This is a single line.")]
@@ -15,22 +15,44 @@ Line 2."
 )]
 fn multi_lines2() {}
 
+#[doc = " Line 1."]
+#[safety(
+    Property,
+    memo = "
+    Line 2.
+    Line 3."
+)]
+fn multi_lines3() {}
+
+#[doc = " Line 1."]
+#[safety(
+    Property,
+    memo = "
+    Line 2.
+    Line 3."
+)]
+#[safety(Property, memo = "Line 4.")]
+fn multi_lines4() {}
+
+//  WARNING: dont't put `#[doc]` (i.e. `///`) after `#[safety(memo)]`
+// because the doc order will be messed up.
+
 #[safety(
     Property,
     memo = "
     Line 1.
     Line 2."
 )]
-#[doc = " Line 3."]
-fn multi_lines3() {}
+#[doc = " Line 3."] // don't do this.
+fn multi_lines3_DONT_DO_THIS() {}
 
 /// Line 1.
 #[safety(Property, memo = "Line 2.\nLine 3.")]
-#[doc = " Line 4."]
-fn multi_lines4() {}
+#[doc = " Line 4."] // don't do this.
+fn multi_lines4_DONT_DO_THIS() {}
 
 /// Line 1.
 #[safety(Property, memo = "Line 2.\nLine 3.")]
 #[safety(Property, memo = "Line 4.")]
-#[doc = " Line 5."]
-fn multi_lines5() {}
+#[doc = " Line 5."] // don't do this.
+fn multi_lines5_DONT_DO_THIS() {}

--- a/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/memo_testcase.rs
@@ -1,3 +1,5 @@
+#![feature(register_tool)]
+#![register_tool(Safety)]
 #![allow(dead_code, non_snake_case)]
 use safety_tool_macro as safety;
 

--- a/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
@@ -1,5 +1,5 @@
 #![feature(prelude_import)]
-#![allow(dead_code)]
+#![allow(dead_code, non_snake_case)]
 #[prelude_import]
 use std::prelude::rust_2024::*;
 #[macro_use]
@@ -17,17 +17,26 @@ fn multi_lines2() {}
 /// Line 2.
 /// Line 3.
 fn multi_lines3() {}
+/// Line 1.
 /// Line 2.
 /// Line 3.
-/// Line 1.
 /// Line 4.
 fn multi_lines4() {}
+/// Line 3.
+/// Line 1.
+/// Line 2.
+fn multi_lines3_DONT_DO_THIS() {}
+/// Line 1.
 /// Line 4.
 /// Line 2.
 /// Line 3.
+fn multi_lines4_DONT_DO_THIS() {}
 /// Line 1.
 /// Line 5.
-fn multi_lines5() {}
+/// Line 2.
+/// Line 3.
+/// Line 4.
+fn multi_lines5_DONT_DO_THIS() {}
 #[rustc_main]
 #[coverage(off)]
 #[doc(hidden)]

--- a/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
@@ -17,6 +17,17 @@ fn multi_lines2() {}
 /// Line 2.
 /// Line 3.
 fn multi_lines3() {}
+/// Line 2.
+/// Line 3.
+/// Line 1.
+/// Line 4.
+fn multi_lines4() {}
+/// Line 4.
+/// Line 2.
+/// Line 3.
+/// Line 1.
+/// Line 5.
+fn multi_lines5() {}
 #[rustc_main]
 #[coverage(off)]
 #[doc(hidden)]

--- a/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
@@ -1,0 +1,26 @@
+#![feature(prelude_import)]
+#![allow(dead_code)]
+#[prelude_import]
+use std::prelude::rust_2024::*;
+#[macro_use]
+extern crate std;
+use safety_tool_macro::safety;
+/// This is a single line.
+fn single_line() {}
+/// Line 1.
+/// Line 2.
+fn multi_lines() {}
+/// Line 1.
+/// Line 2.
+fn multi_lines2() {}
+/// Line 1.
+/// Line 2.
+/// Line 3.
+fn multi_lines3() {}
+#[rustc_main]
+#[coverage(off)]
+#[doc(hidden)]
+pub fn main() -> () {
+    extern crate test;
+    test::test_main_static(&[])
+}

--- a/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
@@ -4,7 +4,7 @@
 use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
-use safety_tool_macro::safety;
+use safety_tool_macro as safety;
 /// This is a single line.
 fn single_line() {}
 /// Line 1.

--- a/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
+++ b/demo/rustc_driver/safety-tool-macro/tests/snapshots/memo_testcase.rs
@@ -1,4 +1,6 @@
 #![feature(prelude_import)]
+#![feature(register_tool)]
+#![register_tool(Safety)]
 #![allow(dead_code, non_snake_case)]
 #[prelude_import]
 use std::prelude::rust_2024::*;
@@ -6,36 +8,54 @@ use std::prelude::rust_2024::*;
 extern crate std;
 use safety_tool_macro as safety;
 /// This is a single line.
+#[Safety::inner(Property, kind = "precond", memo = "This is a single line.")]
 fn single_line() {}
 /// Line 1.
 /// Line 2.
+#[Safety::inner(Property, kind = "hazard", memo = "Line 1.\nLine 2.")]
 fn multi_lines() {}
 /// Line 1.
 /// Line 2.
+#[Safety::inner(Property, kind = "option", memo = "
+Line 1.
+Line 2.")]
 fn multi_lines2() {}
 /// Line 1.
 /// Line 2.
 /// Line 3.
+#[Safety::inner(Property, kind = "precond", memo = "
+    Line 2.
+    Line 3.")]
 fn multi_lines3() {}
 /// Line 1.
 /// Line 2.
 /// Line 3.
+#[Safety::inner(Property, kind = "hazard", memo = "
+    Line 2.
+    Line 3.")]
 /// Line 4.
+#[Safety::inner(Property, kind = "option", memo = "Line 4.")]
 fn multi_lines4() {}
 /// Line 3.
 /// Line 1.
 /// Line 2.
+#[Safety::inner(Property, kind = "precond", memo = "
+    Line 1.
+    Line 2.")]
 fn multi_lines3_DONT_DO_THIS() {}
 /// Line 1.
 /// Line 4.
 /// Line 2.
 /// Line 3.
+#[Safety::inner(Property, kind = "precond", memo = "Line 2.\nLine 3.")]
 fn multi_lines4_DONT_DO_THIS() {}
 /// Line 1.
 /// Line 5.
 /// Line 2.
 /// Line 3.
+#[Safety::inner(Property, kind = "precond", memo = "Line 2.\nLine 3.")]
 /// Line 4.
+#[Safety::inner(Property, kind = "precond", memo = "Line 4.")]
 fn multi_lines5_DONT_DO_THIS() {}
 #[rustc_main]
 #[coverage(off)]

--- a/demo/rustc_driver/safety-tool-parser/Cargo.toml
+++ b/demo/rustc_driver/safety-tool-parser/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "safety-tool-parser"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+quote = "1"
+syn = { version = "2", features = ["extra-traits", "full"] }
+proc-macro2 = "1"

--- a/demo/rustc_driver/safety-tool-parser/src/lib.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/lib.rs
@@ -1,0 +1,4 @@
+pub use quote;
+pub use syn;
+
+pub mod precond;

--- a/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
@@ -28,7 +28,7 @@ impl FnItem {
         FnItem { fn_ }
     }
 
-    pub fn insert_doc_string_to_the_back(&mut self, tokens: Vec<TokenStream>) {
+    pub fn insert_doc_comments_to_the_back(&mut self, tokens: Vec<TokenStream>) {
         // Double check the given tokens are attributes.
         let tokens: TokenStream = tokens.into_iter().collect();
         let attrs = Attribute::parse_outer.parse2(tokens).unwrap();

--- a/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
@@ -1,0 +1,41 @@
+//! `#[safety]` attribute will generate safety doc (`#[doc]`), which will bring interactions
+//! with `#[doc]` from user.
+//!
+//! Consider the following doc strings:
+//!
+//! ```ignore
+//! /// Beginning
+//! #[safety(memo = "safety doc")]
+//! /// Tailling
+//! ```
+//!
+//! It'd be pretty bad if the order is messed up.
+//!
+//! Thus this module should solve this problem by ensuring the doc attribute
+//! emission is inserted to the tail. Because attribute macros are handled
+//! from top to buttom, this hopefully keeps doc orders.
+
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{parse::Parser, *};
+
+pub struct FnItem {
+    pub fn_: ItemFn,
+}
+
+impl FnItem {
+    pub fn new(fn_: ItemFn) -> Self {
+        FnItem { fn_ }
+    }
+
+    pub fn insert_doc_string_to_the_back(&mut self, tokens: Vec<TokenStream>) {
+        // Double check the given tokens are attributes.
+        let tokens: TokenStream = tokens.into_iter().collect();
+        let attrs = Attribute::parse_outer.parse2(tokens).unwrap();
+        self.fn_.attrs.extend(attrs);
+    }
+
+    pub fn into_token_stream(self) -> TokenStream {
+        self.fn_.to_token_stream()
+    }
+}

--- a/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
@@ -28,7 +28,7 @@ impl FnItem {
         FnItem { fn_ }
     }
 
-    pub fn insert_doc_comments_to_the_back(&mut self, tokens: TokenStream) {
+    pub fn insert_attributes_to_the_back(&mut self, tokens: TokenStream) {
         // Double check the given tokens are attributes.
         let attrs = Attribute::parse_outer.parse2(tokens).unwrap();
         self.fn_.attrs.extend(attrs);

--- a/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/keep_doc_order.rs
@@ -28,9 +28,8 @@ impl FnItem {
         FnItem { fn_ }
     }
 
-    pub fn insert_doc_comments_to_the_back(&mut self, tokens: Vec<TokenStream>) {
+    pub fn insert_doc_comments_to_the_back(&mut self, tokens: TokenStream) {
         // Double check the given tokens are attributes.
-        let tokens: TokenStream = tokens.into_iter().collect();
         let attrs = Attribute::parse_outer.parse2(tokens).unwrap();
         self.fn_.attrs.extend(attrs);
     }

--- a/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
@@ -8,6 +8,9 @@ use syn::{
 
 mod utils;
 
+mod keep_doc_order;
+pub use keep_doc_order::FnItem;
+
 #[cfg(test)]
 mod tests;
 

--- a/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
@@ -1,4 +1,5 @@
 use proc_macro2::TokenStream;
+use quote::{ToTokens, quote};
 use std::collections::BTreeSet;
 use syn::{
     parse::{Parse, ParseStream},
@@ -54,6 +55,13 @@ impl SafetyAttrArgs {
     pub fn generate_doc_comments(&self) -> TokenStream {
         NamedArgsSet::new(&self.named).generate_doc_comments()
     }
+
+    pub fn generate_safety_tool_attribute(&self, kind: &str) -> TokenStream {
+        let Self { expr, named, .. } = self;
+        quote! {
+            #[Safety::inner(#expr, kind = #kind, #named)]
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -69,10 +77,19 @@ impl Parse for NamedArgs {
     }
 }
 
+impl ToTokens for NamedArgs {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.name.to_tokens(tokens);
+        self.eq.to_tokens(tokens);
+        self.expr.to_tokens(tokens);
+    }
+}
+
 //  ******************** Attribute Analyzing ********************
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum NamedArg {
+pub enum NamedArg {
+    Kind(String),
     Memo(String),
 }
 
@@ -85,13 +102,21 @@ impl NamedArg {
             return NamedArg::Memo(memo.value());
         }
 
+        if ident == "kind"
+            && let Expr::Lit(lit) = expr
+            && let Lit::Str(kind) = &lit.lit
+        {
+            return NamedArg::Memo(kind.value());
+        }
+
         panic!("{ident:?} is not a supported ident.\nCurrently supported named arguments: memo.")
     }
 
     /// Like generate rustdoc attributes to display doc comment in rustdoc HTML.
-    fn generate_doc_comments(&self) -> Vec<TokenStream> {
+    fn generate_doc_comments(&self) -> TokenStream {
         match self {
             NamedArg::Memo(memo) => utils::memo(memo),
+            _ => TokenStream::new(),
         }
     }
 }

--- a/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
@@ -1,0 +1,57 @@
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    *,
+};
+
+#[derive(Debug)]
+pub struct SafetyAttr {
+    pub attr: Attribute,
+    pub args: SafetyAttrArgs,
+}
+
+impl Parse for SafetyAttr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attrs = Attribute::parse_outer(input)?;
+        let attr = attrs.remove(0);
+        let args = attr.parse_args()?;
+        Ok(SafetyAttr { attr, args })
+    }
+}
+
+#[derive(Debug)]
+pub struct SafetyAttrArgs {
+    pub expr: Expr,
+    pub comma: Option<Token![,]>,
+    pub named: Punctuated<NamedArgs, Token![,]>,
+}
+
+impl Parse for SafetyAttrArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(SafetyAttrArgs {
+            expr: input.parse()?,
+            comma: input.parse()?,
+            named: Punctuated::parse_separated_nonempty(input)?,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct NamedArgs {
+    pub name: Ident,
+    pub eq: Token![=],
+    pub expr: Expr,
+}
+
+impl Parse for NamedArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(NamedArgs { name: input.parse()?, eq: input.parse()?, expr: input.parse()? })
+    }
+}
+
+#[test]
+fn precond_align() {
+    let attr = r#"#[safety::precond(Align(self.ptr, T), memo = "reason")]"#;
+    let safety_attr: SafetyAttr = parse_str(attr).unwrap();
+    dbg!(&safety_attr);
+}

--- a/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
@@ -51,8 +51,8 @@ impl Parse for SafetyAttrArgs {
 }
 
 impl SafetyAttrArgs {
-    pub fn generate_code(&self) -> Vec<TokenStream> {
-        NamedArgsSet::new(&self.named).generate_code()
+    pub fn generate_doc_comments(&self) -> Vec<TokenStream> {
+        NamedArgsSet::new(&self.named).generate_doc_comments()
     }
 }
 
@@ -89,7 +89,7 @@ impl NamedArg {
     }
 
     /// Like generate rustdoc attributes to display doc comment in rustdoc HTML.
-    fn generate_code(&self) -> Vec<TokenStream> {
+    fn generate_doc_comments(&self) -> Vec<TokenStream> {
         match self {
             NamedArg::Memo(memo) => utils::memo(memo),
         }
@@ -108,7 +108,7 @@ impl NamedArgsSet {
         }
     }
 
-    fn generate_code(&self) -> Vec<TokenStream> {
-        self.set.iter().flat_map(NamedArg::generate_code).collect()
+    fn generate_doc_comments(&self) -> Vec<TokenStream> {
+        self.set.iter().flat_map(NamedArg::generate_doc_comments).collect()
     }
 }

--- a/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/mod.rs
@@ -51,7 +51,7 @@ impl Parse for SafetyAttrArgs {
 }
 
 impl SafetyAttrArgs {
-    pub fn generate_doc_comments(&self) -> Vec<TokenStream> {
+    pub fn generate_doc_comments(&self) -> TokenStream {
         NamedArgsSet::new(&self.named).generate_doc_comments()
     }
 }
@@ -108,7 +108,7 @@ impl NamedArgsSet {
         }
     }
 
-    fn generate_doc_comments(&self) -> Vec<TokenStream> {
+    fn generate_doc_comments(&self) -> TokenStream {
         self.set.iter().flat_map(NamedArg::generate_doc_comments).collect()
     }
 }

--- a/demo/rustc_driver/safety-tool-parser/src/precond/tests.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/tests.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[test]
+fn precond_align() {
+    let attr = r#"#[safety::precond(Align(self.ptr, T), memo = "reason")]"#;
+    let safety_attr: SafetyAttr = parse_str(attr).unwrap();
+    dbg!(&safety_attr);
+}

--- a/demo/rustc_driver/safety-tool-parser/src/precond/utils.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/utils.rs
@@ -4,7 +4,7 @@ use quote::quote;
 /// memo = "reason" will generate `///reason`. which is a bit ugly.
 /// So this function trim all whitespaces, and add single one for
 /// each line.
-pub fn memo(s: &str) -> Vec<TokenStream> {
+pub fn memo(s: &str) -> TokenStream {
     s.trim()
         .lines()
         .map(|line| {

--- a/demo/rustc_driver/safety-tool-parser/src/precond/utils.rs
+++ b/demo/rustc_driver/safety-tool-parser/src/precond/utils.rs
@@ -1,0 +1,15 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// memo = "reason" will generate `///reason`. which is a bit ugly.
+/// So this function trim all whitespaces, and add single one for
+/// each line.
+pub fn memo(s: &str) -> Vec<TokenStream> {
+    s.trim()
+        .lines()
+        .map(|line| {
+            let doc = format!(" {}", line.trim());
+            quote!(#[doc = #doc])
+        })
+        .collect()
+}

--- a/demo/rustc_driver/src/bin/cargo-safe-tool.rs
+++ b/demo/rustc_driver/src/bin/cargo-safe-tool.rs
@@ -3,20 +3,20 @@ use std::{env::var, process::Command};
 fn main() {
     // Search cargo-safe-tool and safe-tool CLI through environment variables,
     // or just use the name if absent.
-    let cargo_safe_tool = &*var("CARGO_SATE_TOOL").unwrap_or_else(|_| "cargo-safe-tool".to_owned());
+    let cargo_safe_tool = &*var("CARGO_SAFE_TOOL").unwrap_or_else(|_| "cargo-safe-tool".to_owned());
     let safe_tool = &*var("SAFE_TOOL").unwrap_or_else(|_| "safe-tool".to_owned());
 
-    let mut args = std::env::args().collect::<Vec<_>>();
+    let args = std::env::args().collect::<Vec<_>>();
 
     if args.len() == 2 && args[1].as_str() == "-vV" {
         // cargo invokes `rustc -vV` first
         run("rustc", &["-vV".to_owned()], &[]);
     } else if std::env::var("WRAPPER").as_deref() == Ok("1") {
         // then cargo invokes `rustc - --crate-name ___ --print=file-names`
-        if args[1] == "-" {
-            // `rustc -` is a substitute file name from stdin
-            args[1] = "src/lib.rs".to_owned();
-        }
+        // if args[1] == "-" {
+        //     // `rustc -` is a substitute file name from stdin
+        //     args[1] = "src/main.rs".to_owned();
+        // }
 
         run(safe_tool, &args[1..], &[]);
     } else {

--- a/demo/rustc_driver/src/bin/cargo-safe-tool.rs
+++ b/demo/rustc_driver/src/bin/cargo-safe-tool.rs
@@ -1,10 +1,10 @@
 use std::{env::var, process::Command};
 
 fn main() {
-    // Search cargo-tag-std and tag-std CLI through environment variables,
+    // Search cargo-safe-tool and safe-tool CLI through environment variables,
     // or just use the name if absent.
-    let cargo_tag_std = var("CARGO_TAG_STD").unwrap_or_else(|_| "cargo-tag-std".to_owned());
-    let tag_std = var("TAG_STD").unwrap_or_else(|_| "tag-std".to_owned());
+    let cargo_safe_tool = &*var("CARGO_SATE_TOOL").unwrap_or_else(|_| "cargo-safe-tool".to_owned());
+    let safe_tool = &*var("SAFE_TOOL").unwrap_or_else(|_| "safe-tool".to_owned());
 
     let mut args = std::env::args().collect::<Vec<_>>();
 
@@ -18,9 +18,9 @@ fn main() {
             args[1] = "src/lib.rs".to_owned();
         }
 
-        run(&tag_std, &args[1..], &[]);
+        run(safe_tool, &args[1..], &[]);
     } else {
-        run("cargo", &["build"].map(String::from), &[("RUSTC", &cargo_tag_std), ("WRAPPER", "1")]);
+        run("cargo", &["build"].map(String::from), &[("RUSTC", cargo_safe_tool), ("WRAPPER", "1")]);
     }
 }
 
@@ -35,6 +35,6 @@ fn run(cmd: &str, args: &[String], vars: &[(&str, &str)]) {
         .wait()
         .unwrap();
     if !status.success() {
-        eprintln!("[error] {cmd}: args={args:?} vars={vars:?}");
+        eprintln!("[error] {cmd}: args={args:#?} vars={vars:?}");
     }
 }

--- a/demo/rustc_driver/src/main.rs
+++ b/demo/rustc_driver/src/main.rs
@@ -36,8 +36,8 @@ fn analyze(tcx: TyCtxt) {
     for fun in functions {
         let instance = match Instance::try_from(*fun) {
             Ok(instance) => instance,
-            Err(err) => {
-                eprintln!("Failed to get the instance for {fun:?}:\n{err:?}");
+            Err(_) => {
+                // eprintln!("Failed to get the instance for {fun:?}:\n{err:?}");
                 continue;
             }
         };

--- a/demo/rustc_driver/src/main.rs
+++ b/demo/rustc_driver/src/main.rs
@@ -78,7 +78,7 @@ impl Reachability {
     }
 }
 
-const REGISTER_TOOL: &str = "safety_tool_macro";
+const REGISTER_TOOL: &str = "Safety";
 
 fn print_tag_std_attrs_through_internal_apis(tcx: TyCtxt<'_>, instance: &Instance) {
     let def_id = internal(tcx, instance.def.def_id());

--- a/demo/rustc_driver/tests/basic/Cargo.toml
+++ b/demo/rustc_driver/tests/basic/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+safety-tool-macro = { path = "../../safety-tool-macro/" }

--- a/demo/rustc_driver/tests/basic/Cargo.toml
+++ b/demo/rustc_driver/tests/basic/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-safety-tool-macro = { path = "../../safety-tool-macro/" }
+safety-tool-lib = { path = "../../safety-tool-lib" }

--- a/demo/rustc_driver/tests/basic/macro-expanded/cargo-safe-tool.txt
+++ b/demo/rustc_driver/tests/basic/macro-expanded/cargo-safe-tool.txt
@@ -1,0 +1,37 @@
+********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "build_script_build" [Executable] has reached 156 instances *********
+********* "proc_macro2" [Rlib] has reached 1106 instances *********
+********* "quote" [Rlib] has reached 505 instances *********
+********* "syn" [Rlib] has reached 6924 instances *********
+********* "safety_tool_parser" [Rlib] has reached 707 instances *********
+********* "safety_tool_macro" [ProcMacro] has reached 35 instances *********
+********* "safety_tool_lib" [Rlib] has reached 0 instances *********
+********* "demo" [Rlib] has reached 8 instances *********
+"test" ("src/lib.rs:12:1: 12:26")
+ => "#[Safety::inner(UnReachable, kind = \"precond\", memo =\n\"It's undefined behavior to reach code marked with this intrinsic function.\")]\n"
+
+"MyStruct::get" ("src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(Init(self.ptr, u8, self.len), kind = \"precond\", memo =\n\"The ptr must be initialized first!\")]\n"
+
+"MyStruct::get" ("src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(InBound(self.ptr, u8, self.len), kind = \"precond\", memo =\n\"The ptr must be within the length.\")]\n"
+
+"MyStruct::get" ("src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(ValidNum(self.len * sizeof(u8), [0, isize :: MAX]), kind =\n\"precond\", memo =\n\"Slice length can't exceed isize::MAX due to allocation limit.\")]\n"
+
+"MyStruct::get" ("src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(Alias(self.ptr), kind = \"hazard\", memo =\n\"Make sure don't alias the ptr.\")]\n"
+
+********* "demo" [Executable] has reached 18 instances *********
+"demo::MyStruct::get" ("/home/gh-zjp-CN/tag-std/demo/rustc_driver/tests/basic/src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(Init(self.ptr, u8, self.len), kind = \"precond\", memo =\n\"The ptr must be initialized first!\")]\n"
+
+"demo::MyStruct::get" ("/home/gh-zjp-CN/tag-std/demo/rustc_driver/tests/basic/src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(InBound(self.ptr, u8, self.len), kind = \"precond\", memo =\n\"The ptr must be within the length.\")]\n"
+
+"demo::MyStruct::get" ("/home/gh-zjp-CN/tag-std/demo/rustc_driver/tests/basic/src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(ValidNum(self.len * sizeof(u8), [0, isize :: MAX]), kind =\n\"precond\", memo =\n\"Slice length can't exceed isize::MAX due to allocation limit.\")]\n"
+
+"demo::MyStruct::get" ("/home/gh-zjp-CN/tag-std/demo/rustc_driver/tests/basic/src/lib.rs:40:5: 40:42")
+ => "#[Safety::inner(Alias(self.ptr), kind = \"hazard\", memo =\n\"Make sure don't alias the ptr.\")]\n"
+

--- a/demo/rustc_driver/tests/basic/macro-expanded/lib.rs
+++ b/demo/rustc_driver/tests/basic/macro-expanded/lib.rs
@@ -1,0 +1,55 @@
+#![feature(prelude_import)]
+#![feature(register_tool)]
+#![register_tool(Safety)]
+#![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
+#![feature(core_intrinsics)]
+#[prelude_import]
+use std::prelude::rust_2024::*;
+#[macro_use]
+extern crate std;
+use safety_tool_lib::safety;
+/// It's undefined behavior to reach code marked with this intrinsic function.
+#[Safety::inner(
+    UnReachable,
+    kind = "precond",
+    memo = "It's undefined behavior to reach code marked with this intrinsic function."
+)]
+pub unsafe fn test() -> ! {
+    unsafe { std::intrinsics::unreachable() }
+}
+pub struct MyStruct {
+    ptr: *mut u8,
+    len: usize,
+}
+impl MyStruct {
+    pub fn from(p: *mut u8, l: usize) -> MyStruct {
+        MyStruct { ptr: p, len: l }
+    }
+    /// The ptr must be initialized first!
+    #[Safety::inner(
+        Init(self.ptr, u8, self.len),
+        kind = "precond",
+        memo = "The ptr must be initialized first!"
+    )]
+    /// The ptr must be within the length.
+    #[Safety::inner(
+        InBound(self.ptr, u8, self.len),
+        kind = "precond",
+        memo = "The ptr must be within the length."
+    )]
+    /// Slice length can't exceed isize::MAX due to allocation limit.
+    #[Safety::inner(
+        ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
+        kind = "precond",
+        memo = "Slice length can't exceed isize::MAX due to allocation limit."
+    )]
+    /// Make sure don't alias the ptr.
+    #[Safety::inner(
+        Alias(self.ptr),
+        kind = "hazard",
+        memo = "Make sure don't alias the ptr."
+    )]
+    pub unsafe fn get(&self) -> &mut [u8] {
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+    }
+}

--- a/demo/rustc_driver/tests/basic/src/lib.rs
+++ b/demo/rustc_driver/tests/basic/src/lib.rs
@@ -1,9 +1,12 @@
-#![feature(register_tool)]
-#![register_tool(safety)]
+// #![feature(register_tool)]
+// #![register_tool(safety)]
 #![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
 #![feature(core_intrinsics)]
 
-#[safety::precond::UnReachable(
+use safety_tool_macro::safety;
+
+#[safety(
+    UnReachable,
     memo = "It's undefined behavior to reach code marked with this intrinsic function."
 )]
 pub unsafe fn test() -> ! {
@@ -18,22 +21,22 @@ impl MyStruct {
     pub fn from(p: *mut u8, l: usize) -> MyStruct {
         MyStruct { ptr: p, len: l }
     }
-    #[safety::precond::Init(
-        self.ptr, u8, self.len,
+    #[safety(
+        Init(self.ptr, u8, self.len),
         memo = "The ptr must be initialized first!"
     )]
-    #[safety::precond::InBound(
-        self.ptr, u8, self.len,
-        memo = "The ptr must be within the length."
-    )]
-    #[safety::precond::ValidNum(
-        self.len*sizeof(u8), [0,isize::MAX],
-        memo = "Slice length can't exceed isize::MAX due to allocation limit."
-    )]
-    #[safety::hazard::Alias(
-        self.ptr,
-        memo = "Make sure don't alias the ptr."
-    )]
+    // #[safety::precond::InBound(
+    //     self.ptr, u8, self.len,
+    //     memo = "The ptr must be within the length."
+    // )]
+    // #[safety::precond::ValidNum(
+    //     self.len*sizeof(u8), [0,isize::MAX],
+    //     memo = "Slice length can't exceed isize::MAX due to allocation limit."
+    // )]
+    // #[safety::hazard::Alias(
+    //     self.ptr,
+    //     memo = "Make sure don't alias the ptr."
+    // )]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/demo/rustc_driver/tests/basic/src/lib.rs
+++ b/demo/rustc_driver/tests/basic/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
 #![feature(core_intrinsics)]
 
-use safety_tool_macro as safety;
+use safety_tool_lib::safety;
 
 #[safety::precond(
     UnReachable,

--- a/demo/rustc_driver/tests/basic/src/lib.rs
+++ b/demo/rustc_driver/tests/basic/src/lib.rs
@@ -1,11 +1,11 @@
-// #![feature(register_tool)]
-// #![register_tool(safety)]
+#![feature(register_tool)]
+#![register_tool(Safety)]
 #![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
 #![feature(core_intrinsics)]
 
-use safety_tool_macro::safety;
+use safety_tool_macro as safety;
 
-#[safety(
+#[safety::precond(
     UnReachable,
     memo = "It's undefined behavior to reach code marked with this intrinsic function."
 )]
@@ -21,22 +21,22 @@ impl MyStruct {
     pub fn from(p: *mut u8, l: usize) -> MyStruct {
         MyStruct { ptr: p, len: l }
     }
-    #[safety(
+    #[safety::precond(
         Init(self.ptr, u8, self.len),
         memo = "The ptr must be initialized first!"
     )]
-    // #[safety::precond::InBound(
-    //     self.ptr, u8, self.len,
-    //     memo = "The ptr must be within the length."
-    // )]
-    // #[safety::precond::ValidNum(
-    //     self.len*sizeof(u8), [0,isize::MAX],
-    //     memo = "Slice length can't exceed isize::MAX due to allocation limit."
-    // )]
-    // #[safety::hazard::Alias(
-    //     self.ptr,
-    //     memo = "Make sure don't alias the ptr."
-    // )]
+    #[safety::precond(
+        InBound(self.ptr, u8, self.len),
+        memo = "The ptr must be within the length."
+    )]
+    #[safety::precond(
+        ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
+        memo = "Slice length can't exceed isize::MAX due to allocation limit."
+    )]
+    #[safety::hazard(
+        Alias(self.ptr),
+        memo = "Make sure don't alias the ptr."
+    )]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/demo/rustc_driver/tests/basic/src/lib.rs
+++ b/demo/rustc_driver/tests/basic/src/lib.rs
@@ -1,9 +1,13 @@
 #![feature(register_tool)]
 #![register_tool(safety)]
+#![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
+#![feature(core_intrinsics)]
 
-#[safety::precond(!Reachable())]
-pub unsafe fn test() {
-    println!("unreachable!");
+#[safety::precond::UnReachable(
+    memo = "It's undefined behavior to reach code marked with this intrinsic function."
+)]
+pub unsafe fn test() -> ! {
+    unsafe { std::intrinsics::unreachable() }
 }
 
 pub struct MyStruct {
@@ -14,10 +18,22 @@ impl MyStruct {
     pub fn from(p: *mut u8, l: usize) -> MyStruct {
         MyStruct { ptr: p, len: l }
     }
-    #[safety::precond::Init(self.ptr, u8, self.len)]
-    #[safety::precond::InBound(self.ptr, u8, self.len)]
-    #[safety::precond::ValidNum(self.len*sizeof(u8), [0,isize::MAX])]
-    #[safety::hazard::Alias(self.ptr)]
+    #[safety::precond::Init(
+        self.ptr, u8, self.len,
+        memo = "The ptr must be initialized first!"
+    )]
+    #[safety::precond::InBound(
+        self.ptr, u8, self.len,
+        memo = "The ptr must be within the length."
+    )]
+    #[safety::precond::ValidNum(
+        self.len*sizeof(u8), [0,isize::MAX],
+        memo = "Slice length can't exceed isize::MAX due to allocation limit."
+    )]
+    #[safety::hazard::Alias(
+        self.ptr,
+        memo = "Make sure don't alias the ptr."
+    )]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }


### PR DESCRIPTION
This PR mainly implements safety attribute proc-macros listed in the title
* close https://github.com/Artisan-Lab/tag-std/issues/6
* cc #2

For example,  `#[precond]`  will expand to
* [`#[doc]`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html)  which is used to generate rustdoc content
* `#[Safety::inner(Property, kind = "precond", ...)]` a [registered tool attribute](https://github.com/rust-lang/rfcs/pull/3808) , used in the rustc driver with `kind` and `Property` analyzed



```rust
#![feature(register_tool)]
#![register_tool(Safety)]

use safety_tool_lib::safety;

#[safety::precond(
    UnReachable,
    memo = "It's undefined behavior to reach code marked with this intrinsic function."
)]
```

is expanded to

```rust
/// It's undefined behavior to reach code marked with this intrinsic function.
#[Safety::inner(
    UnReachable,
    kind = "precond",
    memo = "It's undefined behavior to reach code marked with this intrinsic function."
)]
```

<details><summary>More examples</summary>
<p>

```rust
#[safety::precond(
    Init(self.ptr, u8, self.len),
    memo = "The ptr must be initialized first!"
)]
#[safety::precond(
    InBound(self.ptr, u8, self.len),
    memo = "The ptr must be within the length."
)]
#[safety::precond(
    ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
    memo = "Slice length can't exceed isize::MAX due to allocation limit."
)]
#[safety::hazard(
    Alias(self.ptr),
    memo = "Make sure don't alias the ptr."
)]
```

expanded to

```rust
/// The ptr must be initialized first!
#[Safety::inner(
    Init(self.ptr, u8, self.len),
    kind = "precond",
    memo = "The ptr must be initialized first!"
)]
/// The ptr must be within the length.
#[Safety::inner(
    InBound(self.ptr, u8, self.len),
    kind = "precond",
    memo = "The ptr must be within the length."
)]
/// Slice length can't exceed isize::MAX due to allocation limit.
#[Safety::inner(
    ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
    kind = "precond",
    memo = "Slice length can't exceed isize::MAX due to allocation limit."
)]
/// Make sure don't alias the ptr.
#[Safety::inner(
    Alias(self.ptr),
    kind = "hazard",
    memo = "Make sure don't alias the ptr."
)]
```

</p>
</details> 

Implementation details:
* `safety-tool-parser` crate is a attribute macro syntax parser, and shared between `safety-tool-macro` and rustc driver
* `safety-tool-macro` crate is a proc-macro lib, used to add `#[doc]` and `#[Safety::inner]` attributes for the annotated function
* `safety-tool-lib` crate is mainly for public use, especially for another tool like klint
  * the lib crate will contain the analysis routines

NOTE: the registered tool attribute is changed from `safety` to `Safety`.

