### PR TITLE
feat: `#[safety::discharge(Memo(UserProperty))]`

### DIFF
--- a/demo/safety-tool-lib/src/safety.rs
+++ b/demo/safety-tool-lib/src/safety.rs
@@ -1,4 +1,5 @@
 pub use safety_tool_macro::Memo;
+pub use safety_tool_macro::discharge;
 
 use safety_tool_macro::pub_use;
 pub mod precond {

--- a/demo/safety-tool-macro/src/lib.rs
+++ b/demo/safety-tool-macro/src/lib.rs
@@ -105,3 +105,8 @@ pub fn pub_use(tokens: TokenStream) -> TokenStream {
 pub fn Memo(attr: TokenStream, item: TokenStream) -> TokenStream {
     generate(Kind::Memo, PropertyName::Unknown, attr, item)
 }
+
+#[proc_macro_attribute]
+pub fn discharge(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    item
+}

--- a/demo/tests/src/main.rs
+++ b/demo/tests/src/main.rs
@@ -1,10 +1,13 @@
+#![feature(proc_macro_hygiene)]
 #![feature(vec_into_raw_parts)]
 #![allow(unused_variables)]
 
 use demo::MyStruct;
+use safety_tool_lib::safety;
 
 fn main() {
     let (p, l, _c) = Vec::new().into_raw_parts();
+    #[safety::discharge(Memo(UserProperty))]
     let a = MyStruct::from(p, l);
     println!("{:?}", unsafe { a.get() });
 }


### PR DESCRIPTION
This is a ghost implementation. Only to demonstrate the  `#[discharge]` syntax.