### PR TITLE
CI: run safety-tool on Rust for linux

### DIFF
--- a/.github/rust-for-linux/check.sh
+++ b/.github/rust-for-linux/check.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# modified from https://github.com/rust-lang/rust/blob/bc4376fa73b636eb6f2c7d48b1f731d70f022c4b/src/ci/docker/scripts/rfl-build.sh
+
+set -exou pipefail
+
+# Rust toolchain
+RUST_TOOLCHAIN=1.87
+
+rustup default $RUST_TOOLCHAIN
+
+# Set up dynamic link path for rustc driver.
+export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
+
+# This should print `rustc 1.87.0 (17067e9ac 2025-05-09)`.
+safety-tool --version
+
+# Download LLVM and rustc toolchain required by Rust for Linux
+# see https://mirrors.edge.kernel.org/pub/tools/llvm/rust/
+llvm=llvm-20.1.7-rust-1.87.0-x86_64
+wget https://mirrors.edge.kernel.org/pub/tools/llvm/rust/files/$llvm.tar.xz
+tar -xvf $llvm.tar.xz
+
+# Add llvm to PATH, and set up libclang
+llvm_prefix=$PWD/$llvm
+export PATH=$llvm_prefix/bin:$PATH
+export LIBCLANG_PATH=$llvm_prefix/lib/libclang.so
+
+# Install bindgen-cli which must be built from the same version of
+# libclang and rustc required above.
+cargo --version
+cargo install --locked --root $llvm_prefix --version $(linux/scripts/min-tool-version.sh bindgen) bindgen-cli
+
+# Prepare Rust for Linux config
+cat <<EOF >linux/kernel/configs/rfl-for-rust-ci.config
+# CONFIG_WERROR is not set
+
+CONFIG_RUST=y
+
+CONFIG_SAMPLES=y
+CONFIG_SAMPLES_RUST=y
+
+CONFIG_SAMPLE_RUST_MINIMAL=m
+CONFIG_SAMPLE_RUST_PRINT=y
+
+CONFIG_RUST_PHYLIB_ABSTRACTIONS=y
+CONFIG_AX88796B_PHY=y
+CONFIG_AX88796B_RUST_PHY=y
+
+CONFIG_KUNIT=y
+CONFIG_RUST_KERNEL_DOCTESTS=y
+EOF
+
+# Merge linux config
+make -C linux LLVM=1 -j$(($(nproc) + 1)) \
+  rustavailable \
+  defconfig \
+  rfl-for-rust-ci.config
+
+BUILD_TARGETS="
+    samples/rust/rust_minimal.o
+    samples/rust/rust_print_main.o
+    drivers/net/phy/ax88796b_rust.o
+    rust/doctests_kernel_generated.o
+"
+
+# Compile rust code by our tool to check it!
+make -C linux LLVM=1 -j$(($(nproc) + 1)) RUSTC=$(which safety-tool) \
+  $BUILD_TARGETS

--- a/.github/rust-for-linux/check.sh
+++ b/.github/rust-for-linux/check.sh
@@ -15,13 +15,8 @@ export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 # This should print `rustc 1.87.0 (17067e9ac 2025-05-09)`.
 safety-tool --version
 
-# Download LLVM and rustc toolchain required by Rust for Linux
-# see https://mirrors.edge.kernel.org/pub/tools/llvm/rust/
-llvm=llvm-20.1.7-rust-1.87.0-x86_64
-wget https://mirrors.edge.kernel.org/pub/tools/llvm/rust/files/$llvm.tar.xz
-tar -xvf $llvm.tar.xz
-
 # Add llvm to PATH, and set up libclang
+llvm=llvm-20.1.7-rust-1.87.0-$(uname -m)
 llvm_prefix=$PWD/$llvm
 export PATH=$llvm_prefix/bin:$PATH
 export LIBCLANG_PATH=$llvm_prefix/lib/libclang.so

--- a/.github/rust-for-linux/install.sh
+++ b/.github/rust-for-linux/install.sh
@@ -13,3 +13,9 @@ git -C linux init
 git -C linux remote add origin https://github.com/Rust-for-Linux/linux.git
 git -C linux fetch --depth 1 origin ${LINUX_VERSION}
 git -C linux checkout FETCH_HEAD
+
+# Download LLVM and rustc toolchain required by Rust for Linux
+# see https://mirrors.edge.kernel.org/pub/tools/llvm/rust/
+llvm=llvm-20.1.7-rust-1.87.0-$(uname -m)
+wget https://mirrors.edge.kernel.org/pub/tools/llvm/rust/files/$llvm.tar.xz
+tar -xvf $llvm.tar.xz

--- a/.github/rust-for-linux/install.sh
+++ b/.github/rust-for-linux/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# modified from https://github.com/rust-lang/rust/blob/bc4376fa73b636eb6f2c7d48b1f731d70f022c4b/src/ci/docker/scripts/rfl-build.sh
+
+set -exou pipefail
+
+# Linux version
+LINUX_VERSION=v6.16-rc1
+
+# Download Linux at a specific commit
+mkdir -p linux
+git -C linux init
+git -C linux remote add origin https://github.com/Rust-for-Linux/linux.git
+git -C linux fetch --depth 1 origin ${LINUX_VERSION}
+git -C linux checkout FETCH_HEAD

--- a/.github/workflows/rust-for-linux.yml
+++ b/.github/workflows/rust-for-linux.yml
@@ -1,0 +1,26 @@
+name: Check Rust for Linux
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tag-std to rust-for-linux branch
+        uses: actions/checkout@v4
+        with:
+          ref: rust-for-linux
+
+      - name: Install safety-tool
+        run: cd safety-tool && cargo install --path . --locked
+
+      - name: Download Linux Repo
+        run: .github/rust-for-linux/install.sh
+
+      - name: Check Linux Repo
+        run: .github/rust-for-linux/check.sh

--- a/.github/workflows/rust-for-linux.yml
+++ b/.github/workflows/rust-for-linux.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           ref: rust-for-linux
 
+      - name: Install deps required by linux
+        run: sudo apt-get install libelf-dev
+
       - name: Install safety-tool
         run: cd safety-tool && cargo install --path . --locked
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 target/
 *.sqlite3
 *.rlib
+/linux
+/llvm*

--- a/safety-tool/.cargo/config.toml
+++ b/safety-tool/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+RUSTC_BOOTSTRAP = "1"

--- a/safety-tool/run.sh
+++ b/safety-tool/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -ex
 set -o pipefail
 

--- a/safety-tool/rust-toolchain.toml
+++ b/safety-tool/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-06-02"
+channel = "1.87"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rust-analyzer", "rustfmt", "clippy"]

--- a/safety-tool/safety-parser/src/lib.rs
+++ b/safety-tool/safety-parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 pub use proc_macro2;
 pub use quote;
 pub use syn;

--- a/safety-tool/src/analyze_hir/visit.rs
+++ b/safety-tool/src/analyze_hir/visit.rs
@@ -93,7 +93,7 @@ fn check_tag_state(
         let span_body = tcx.source_span(hir_id.owner);
         let is = if n == 1 { "is" } else { "are" };
         let title = format!("{undischarged} {is} not discharged");
-        let span_node = tcx.hir_span(hir_id);
+        let span_node = tcx.hir().span(hir_id);
         let anno =
             Level::Error.span(anno_span(span_body, span_node)).label("For this unsafe call.");
         gen_diagnosis(span_body, src_map, &title, anno);

--- a/safety-tool/src/main.rs
+++ b/safety-tool/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(rustc_private)]
+#![feature(let_chains)]
 
 extern crate itertools;
 extern crate rustc_ast;
@@ -16,6 +17,7 @@ extern crate stable_mir;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_hir::Attribute;
 use rustc_middle::ty::TyCtxt;
+use rustc_smir::rustc_internal::{self, internal};
 use stable_mir::{
     CrateDef, ItemKind,
     mir::{
@@ -23,7 +25,6 @@ use stable_mir::{
         mono::{Instance, InstanceKind},
         visit::Location,
     },
-    rustc_internal::internal,
     ty::Ty,
 };
 use std::ops::ControlFlow;
@@ -43,7 +44,7 @@ fn main() {
     } else {
         ControlFlow::<(), ()>::Continue(())
     };
-    _ = run_with_tcx!(&rustc_args, |tcx| {
+    _ = run_with_tcx!(rustc_args, |tcx| {
         analyze_hir::analyze_hir(tcx).unwrap();
         analyze(tcx);
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,55 +1,55 @@
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
-********* "build_script_build" [Executable] has reached 156 instances *********
-********* "proc_macro2" [Rlib] has reached 1060 instances *********
-********* "quote" [Rlib] has reached 506 instances *********
-********* "syn" [Rlib] has reached 6925 instances *********
-********* "safety_parser" [Rlib] has reached 976 instances *********
-********* "safety_macro" [ProcMacro] has reached 352 instances *********
+********* "build_script_build" [Executable] has reached 155 instances *********
+********* "proc_macro2" [Rlib] has reached 1057 instances *********
+********* "quote" [Rlib] has reached 505 instances *********
+********* "syn" [Rlib] has reached 6923 instances *********
+********* "safety_parser" [Rlib] has reached 969 instances *********
+********* "safety_macro" [ProcMacro] has reached 350 instances *********
 ********* "safety_lib" [Rlib] has reached 0 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
 "test" ("src/lib.rs:9:1: 9:26")
- => "#[rapx::inner(property = Unreachable(), kind = \"precond\")]\n"
+ => "#[rapx::inner(property = Unreachable(), kind = \"precond\")]"
 
 "MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Init(self.ptr, u8, self.len), kind = \"precond\")]\n"
+ => "#[rapx::inner(property = Init(self.ptr, u8, self.len), kind = \"precond\")]"
 
 "MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = InBound(self.ptr, u8, self.len), kind = \"precond\")]\n"
+ => "#[rapx::inner(property = InBound(self.ptr, u8, self.len), kind = \"precond\")]"
 
 "MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = ValidNum(self.len * sizeof(u8), [0, isize :: MAX]),\nkind = \"precond\")]\n"
+ => "#[rapx::inner(property = ValidNum(self.len * sizeof(u8), [0, isize :: MAX]),\nkind = \"precond\")]"
 
 "MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Alias(self.ptr), kind = \"hazard\")]\n"
+ => "#[rapx::inner(property = Alias(self.ptr), kind = \"hazard\")]"
 
 "MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Unknown(UserPropertyGet), kind = \"memo\", memo =\n\"Customed user property.\")]\n"
+ => "#[rapx::inner(property = Unknown(UserPropertyGet), kind = \"memo\", memo =\n\"Customed user property.\")]"
 
 "MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Unknown(UserPropertyGet2), kind = \"memo\")]\n"
+ => "#[rapx::inner(property = Unknown(UserPropertyGet2), kind = \"memo\")]"
 
 "MyStruct::from" ("src/lib.rs:19:5: 19:50")
- => "#[rapx::inner(property = Unknown(UserProperty), kind = \"memo\", memo =\n\"Customed user property.\")]\n"
+ => "#[rapx::inner(property = Unknown(UserProperty), kind = \"memo\", memo =\n\"Customed user property.\")]"
 
 ********* "demo" [Executable] has reached 18 instances *********
 "demo::MyStruct::from" ("src/lib.rs:19:5: 19:50")
- => "#[rapx::inner(property = Unknown(UserProperty), kind = \"memo\", memo =\n\"Customed user property.\")]\n"
+ => "#[rapx::inner(property = Unknown(UserProperty), kind = \"memo\", memo =\n\"Customed user property.\")]"
 
 "demo::MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Init(self.ptr, u8, self.len), kind = \"precond\")]\n"
+ => "#[rapx::inner(property = Init(self.ptr, u8, self.len), kind = \"precond\")]"
 
 "demo::MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = InBound(self.ptr, u8, self.len), kind = \"precond\")]\n"
+ => "#[rapx::inner(property = InBound(self.ptr, u8, self.len), kind = \"precond\")]"
 
 "demo::MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = ValidNum(self.len * sizeof(u8), [0, isize :: MAX]),\nkind = \"precond\")]\n"
+ => "#[rapx::inner(property = ValidNum(self.len * sizeof(u8), [0, isize :: MAX]),\nkind = \"precond\")]"
 
 "demo::MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Alias(self.ptr), kind = \"hazard\")]\n"
+ => "#[rapx::inner(property = Alias(self.ptr), kind = \"hazard\")]"
 
 "demo::MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Unknown(UserPropertyGet), kind = \"memo\", memo =\n\"Customed user property.\")]\n"
+ => "#[rapx::inner(property = Unknown(UserPropertyGet), kind = \"memo\", memo =\n\"Customed user property.\")]"
 
 "demo::MyStruct::get" ("src/lib.rs:29:5: 29:42")
- => "#[rapx::inner(property = Unknown(UserPropertyGet2), kind = \"memo\")]\n"
+ => "#[rapx::inner(property = Unknown(UserPropertyGet2), kind = \"memo\")]"
 

--- a/safety-tool/tests/snapshots/unsafe_calls.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls.txt
@@ -1,50 +1,50 @@
 stdout=
 ********* "unsafe_calls" [Rlib] has reached 4 instances *********
 "tag_unsafe_fn" ("./tests/snippets/unsafe_calls.rs:24:1: 24:30")
- => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]"
 
 "call" ("./tests/snippets/unsafe_calls.rs:21:1: 21:17")
- => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]"
 
 
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:3 ~ unsafe_calls[d41f]::tag_expr).5),
-        def_id: DefId(0:5 ~ unsafe_calls[d41f]::call),
+        hir_id: HirId(DefId(0:3 ~ unsafe_calls[5dfd]::tag_expr).5),
+        def_id: DefId(0:5 ~ unsafe_calls[5dfd]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:3 ~ unsafe_calls[d41f]::tag_expr).5) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls[d41f]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls[d41f]::tag_expr).4) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls[d41f]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls[5dfd]::tag_expr).5) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls[5dfd]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls[5dfd]::tag_expr).4) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls[5dfd]::tag_expr).0)
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).5),
-        def_id: DefId(0:5 ~ unsafe_calls[d41f]::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).5),
+        def_id: DefId(0:5 ~ unsafe_calls[5dfd]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).7) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[d41f]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).7) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls[5dfd]::tag_block).0)
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).3),
-        def_id: DefId(0:5 ~ unsafe_calls[d41f]::call),
+        hir_id: HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).3),
+        def_id: DefId(0:5 ~ unsafe_calls[5dfd]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[d41f]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn).0)

--- a/safety-tool/tests/snapshots/unsafe_calls_discharge_all.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_discharge_all.txt
@@ -1,59 +1,59 @@
 stdout=
 ********* "unsafe_calls_discharge_all" [Rlib] has reached 4 instances *********
 "tag_unsafe_fn" ("./tests/snippets/unsafe_calls_discharge_all.rs:28:1: 28:30")
- => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]"
 
 "tag_unsafe_fn" ("./tests/snippets/unsafe_calls_discharge_all.rs:28:1: 28:30")
- => "#[rapx::tag_unsafe_fn(property = Align(), kind = \"precond\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Align(), kind = \"precond\")]"
 
 "call" ("./tests/snippets/unsafe_calls_discharge_all.rs:24:1: 24:17")
- => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]"
 
 "call" ("./tests/snippets/unsafe_calls_discharge_all.rs:24:1: 24:17")
- => "#[rapx::inner(property = Align(), kind = \"precond\")]\n"
+ => "#[rapx::inner(property = Align(), kind = \"precond\")]"
 
 
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:3 ~ unsafe_calls_discharge_all[b6db]::tag_expr).5),
-        def_id: DefId(0:5 ~ unsafe_calls_discharge_all[b6db]::call),
+        hir_id: HirId(DefId(0:3 ~ unsafe_calls_discharge_all[2dfd]::tag_expr).5),
+        def_id: DefId(0:5 ~ unsafe_calls_discharge_all[2dfd]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
     "Precond_Align": false,
 }
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[b6db]::tag_expr).5) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[b6db]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[b6db]::tag_expr).4) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[b6db]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[2dfd]::tag_expr).5) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[2dfd]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[2dfd]::tag_expr).4) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_discharge_all[2dfd]::tag_expr).0)
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).5),
-        def_id: DefId(0:5 ~ unsafe_calls_discharge_all[b6db]::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).5),
+        def_id: DefId(0:5 ~ unsafe_calls_discharge_all[2dfd]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
     "Precond_Align": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).7) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[b6db]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).7) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_discharge_all[2dfd]::tag_block).0)
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).3),
-        def_id: DefId(0:5 ~ unsafe_calls_discharge_all[b6db]::call),
+        hir_id: HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).3),
+        def_id: DefId(0:5 ~ unsafe_calls_discharge_all[2dfd]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
     "Precond_Align": false,
 }
-hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[b6db]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:6 ~ unsafe_calls_discharge_all[2dfd]::tag_unsafe_fn).0)

--- a/safety-tool/tests/snapshots/unsafe_calls_method.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_method.txt
@@ -1,53 +1,53 @@
 stdout=
 ********* "unsafe_calls_method" [Rlib] has reached 5 instances *********
 "tag_unsafe_fn" ("./tests/snippets/unsafe_calls_method.rs:34:1: 34:30")
- => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]"
 
 "Struct::call" ("./tests/snippets/unsafe_calls_method.rs:30:5: 30:26")
- => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]"
 
 
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).12),
-        def_id: DefId(0:8 ~ unsafe_calls_method[946d]::{impl#0}::call),
+        hir_id: HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).12),
+        def_id: DefId(0:8 ~ unsafe_calls_method[2fa5]::{impl#0}::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).12) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).11) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).10) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).16) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).17) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[946d]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).12) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).11) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).10) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).16) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).17) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_method[2fa5]::tag_expr).0)
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).12),
-        def_id: DefId(0:8 ~ unsafe_calls_method[946d]::{impl#0}::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).12),
+        def_id: DefId(0:8 ~ unsafe_calls_method[2fa5]::{impl#0}::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).12) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).16) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).11) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).10) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[946d]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).12) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).16) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).11) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).10) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_method[2fa5]::tag_block).0)
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).10),
-        def_id: DefId(0:8 ~ unsafe_calls_method[946d]::{impl#0}::call),
+        hir_id: HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).10),
+        def_id: DefId(0:8 ~ unsafe_calls_method[2fa5]::{impl#0}::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).10) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).14) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).15) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[946d]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).10) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).14) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).15) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:9 ~ unsafe_calls_method[2fa5]::tag_unsafe_fn).0)

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_assign.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_assign.txt
@@ -3,19 +3,19 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).3),
-        def_id: DefId(0:4 ~ unsafe_calls_panic_assign[42c4]::call),
+        hir_id: HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).3),
+        def_id: DefId(0:4 ~ unsafe_calls_panic_assign[5cd5]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).3) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).5) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).2) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).13) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[42c4]::assign).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).3) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).5) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).2) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).13) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign[5cd5]::assign).0)
 [src/analyze_hir/visit.rs:105:5] &src_body = "pub fn assign() {\n    let f = call;\n    #[rapx::assign(property = Memo(Tag), kind = \"memo\")]\n    unsafe {\n        f()\n    };\n}"
 [1m[91merror[0m: [1m`Tag` is not discharged[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_assign.rs:12:13

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_assign_fn_ptr.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_assign_fn_ptr.txt
@@ -3,19 +3,19 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).4),
-        def_id: DefId(0:4 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::call),
+        hir_id: HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).4),
+        def_id: DefId(0:4 ~ unsafe_calls_panic_assign_fn_ptr[6242]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).4) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).6) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).2) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).14) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[7c8d]::assign_fn_ptr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).4) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).6) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).2) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).14) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_assign_fn_ptr[6242]::assign_fn_ptr).0)
 [src/analyze_hir/visit.rs:105:5] &src_body = "pub fn assign_fn_ptr() {\n    let f: unsafe fn() = call;\n    unsafe {\n        #[rapx::assign_fn_ptr(property = Memo(Tag), kind = \"memo\")]\n        f()\n    };\n}"
 [1m[91merror[0m: [1m`Tag` is not discharged[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_assign_fn_ptr.rs:12:26

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less.txt
@@ -3,20 +3,20 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).3),
-        def_id: DefId(0:3 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).3),
+        def_id: DefId(0:3 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
     "Precond_Align": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[a238]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less[9412]::tag_unsafe_fn).0)
 [src/analyze_hir/visit.rs:105:5] &src_body = "pub unsafe fn tag_unsafe_fn() {\n    call();\n}"
 [1m[91merror[0m: [1m`Precond_Align` is not discharged[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less.rs:9:1

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less_fine.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less_fine.txt
@@ -1,28 +1,28 @@
 stdout=
 ********* "unsafe_calls_panic_discharge_all_tagged_less_fine" [Rlib] has reached 2 instances *********
 "call" ("./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less_fine.rs:8:1: 8:17")
- => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::inner(property = Memo(Tag), kind = \"memo\")]"
 
 "call" ("./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less_fine.rs:8:1: 8:17")
- => "#[rapx::tag_unsafe_fn(property = Align(), kind = \"precond\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Align(), kind = \"precond\")]"
 
 "tag_unsafe_fn" ("./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less_fine.rs:11:1: 11:30")
- => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]"
 
 
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).3),
-        def_id: DefId(0:3 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).3),
+        def_id: DefId(0:3 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[17c6]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_less_fine[126b]::tag_unsafe_fn).0)

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_more.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_more.txt
@@ -3,19 +3,19 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).3),
-        def_id: DefId(0:3 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).3),
+        def_id: DefId(0:3 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[7b38]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_discharge_all_tagged_more[a82d]::tag_unsafe_fn).0)
 [31mThe application panicked (crashed).[0m
 Message:  [36mtag "Precond_Align" doesn't belong to tags ["Tag"][0m
 Location: [35msrc/analyze_hir/visit.rs[0m:[35m46[0m

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_method.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_method.txt
@@ -3,20 +3,20 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).12),
-        def_id: DefId(0:7 ~ unsafe_calls_panic_method[35ad]::{impl#0}::call),
+        hir_id: HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).12),
+        def_id: DefId(0:7 ~ unsafe_calls_panic_method[2a9b]::{impl#0}::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).12) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).16) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).11) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).10) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).17) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
-hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[35ad]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).12) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).16) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).11) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).10) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).1) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).17) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
+hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0) fn_hir_id=HirId(DefId(0:3 ~ unsafe_calls_panic_method[2a9b]::tag_block).0)
 [src/analyze_hir/visit.rs:105:5] &src_body = "pub fn tag_block() {\n    let s = Struct::new();\n    unsafe {\n        s.call();\n    }\n}"
 [1m[91merror[0m: [1m`Tag` is not discharged[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_method.rs:9:9

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_no_tag.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_no_tag.txt
@@ -3,19 +3,19 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).3),
-        def_id: DefId(0:5 ~ unsafe_calls_panic_no_tag[9353]::call),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).3),
+        def_id: DefId(0:5 ~ unsafe_calls_panic_no_tag[fb87]::call),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).7) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[9353]::submod::submod_no_tag).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).6) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).7) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_no_tag[fb87]::submod::submod_no_tag).0)
 [src/analyze_hir/visit.rs:105:5] &src_body = "unsafe fn submod_no_tag() {\n        super::call();\n    }"
 [1m[91merror[0m: [1m`Tag` is not discharged[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_no_tag.rs:13:9

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_with_dep.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_with_dep.txt
@@ -3,20 +3,20 @@ stdout=
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).5),
-        def_id: DefId(20:6 ~ unsafe_calls[d41f]::tag_unsafe_fn),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).5),
+        def_id: DefId(20:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).8) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[6c1a]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).8) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_panic_with_dep[e8de]::use_tag_unsafe_fn).0)
 [src/analyze_hir/visit.rs:105:5] &src_body = "fn use_tag_unsafe_fn() {\n    unsafe { unsafe_calls::tag_unsafe_fn() }\n}"
 [1m[91merror[0m: [1m`Tag` is not discharged[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_with_dep.rs:9:14

--- a/safety-tool/tests/snapshots/unsafe_calls_with_dep.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_with_dep.txt
@@ -1,26 +1,26 @@
 stdout=
 ********* "unsafe_calls_with_dep" [Rlib] has reached 2 instances *********
 "use_tag_unsafe_fn" ("./tests/snippets/unsafe_calls_with_dep.rs:9:1: 9:23")
- => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]"
 
 "unsafe_calls::tag_unsafe_fn" ("./tests/snippets/unsafe_calls.rs:24:1: 24:30")
- => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]\n"
+ => "#[rapx::tag_unsafe_fn(property = Memo(Tag), kind = \"memo\")]"
 
 
 stderr=
 [src/analyze_hir/mod.rs:47:13] &unsafe_calls = [
     Call {
-        hir_id: HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).5),
-        def_id: DefId(20:6 ~ unsafe_calls[d41f]::tag_unsafe_fn),
+        hir_id: HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).5),
+        def_id: DefId(20:6 ~ unsafe_calls[5dfd]::tag_unsafe_fn),
     },
 ]
 [src/analyze_hir/visit.rs:36:9] &tags_state = {
     "Tag": false,
 }
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).8) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
-hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[267d]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).5) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).4) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).3) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).2) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).1) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).8) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)
+hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0) fn_hir_id=HirId(DefId(0:4 ~ unsafe_calls_with_dep[82ca]::use_tag_unsafe_fn).0)


### PR DESCRIPTION
This  PR adds a CI to run safety-tool check on Rust for Linux (rfl). To do it, 
*  backport rust toolchain 1.87 instead of that required by kani
* add `.github/rust-for-linux/{install.sh,check.sh}` scripts for local and CI 
  * install.sh should be executed only once unless fetching linux at another commit
  * check.sh can be executed locally multiple times to see if safety-tool applies to rfl code