### PR TITLE
Feat: build and deploy kernel HTML rustdoc; pass `--extern` to allow `use safety_macro`

### DIFF
--- a/.github/rust-for-linux/check.sh
+++ b/.github/rust-for-linux/check.sh
@@ -69,6 +69,7 @@ BUILD_TARGETS="
     samples/rust/rust_print_main.o
     drivers/net/phy/ax88796b_rust.o
     rust/doctests_kernel_generated.o
+    rustdoc
 "
 
 # Compile rust code by our tool to check it!

--- a/.github/workflows/rust-for-linux.yml
+++ b/.github/workflows/rust-for-linux.yml
@@ -9,6 +9,14 @@ env:
 
 jobs:
   check:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment-ubuntu-latest.outputs.page_url }}
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -30,29 +38,19 @@ jobs:
         run: .github/rust-for-linux/install.sh
 
       - name: make version
-        run: make -v
+        run:  make -v
 
       - name: Check Linux Repo
         run: .github/rust-for-linux/check.sh
 
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        id: deployment-ubuntu-latest
         with:
           path: linux/Documentation/output/rust/rustdoc/
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-
-    needs: check
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        id: deployment-ubuntu-latest
         uses: actions/deploy-pages@v4

--- a/.github/workflows/rust-for-linux.yml
+++ b/.github/workflows/rust-for-linux.yml
@@ -46,11 +46,9 @@ jobs:
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
         if: runner.os == 'Linux' && runner.arch == 'X64'
-        id: deployment-ubuntu-latest
         with:
           path: linux/Documentation/output/rust/rustdoc/
 
       - name: Deploy to GitHub Pages
         if: runner.os == 'Linux' && runner.arch == 'X64'
-        id: deployment-ubuntu-latest
         uses: actions/deploy-pages@v4

--- a/.github/workflows/rust-for-linux.yml
+++ b/.github/workflows/rust-for-linux.yml
@@ -34,3 +34,25 @@ jobs:
 
       - name: Check Linux Repo
         run: .github/rust-for-linux/check.sh
+
+      - name: Upload static files as artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: linux/Documentation/output/rust/rustdoc/
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    needs: check
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/safety-tool/src/bin/safety-tool-rfl-rustdoc/run_rustdoc.rs
+++ b/safety-tool/src/bin/safety-tool-rfl-rustdoc/run_rustdoc.rs
@@ -28,6 +28,9 @@ fn extra_rustc_args() -> Vec<String> {
         // inject safety_lib dependency
         "-L",
         safety_lib.as_str(),
+        // Specify direct dependency to allow `use safety_macro` in crate root.
+        // The use extern crate syntax only works after --edition=2018.
+        "--extern=safety_macro",
         // inject rapx tool attr
         // "-Zallow-features=register_tool",
         "-Zcrate-attr=feature(register_tool)",

--- a/safety-tool/src/bin/safety-tool-rfl/run_safety_tool.rs
+++ b/safety-tool/src/bin/safety-tool-rfl/run_safety_tool.rs
@@ -38,8 +38,15 @@ fn extra_rustc_args() -> Vec<String> {
         // inject safety_lib dependency
         "-L",
         safety_lib.as_str(),
-        // inject rapx tool attr
+        // NOTE: the last -Zallow-features wins, meaning that specified by rfl
+        // previously will be disregarded.
+        // cc https://github.com/rust-lang/rust/issues/143312
         // "-Zallow-features=register_tool",
+        //
+        // Specify direct dependency to allow `use safety_macro` in crate root.
+        // The use extern crate syntax only works after --edition=2018.
+        "--extern=safety_macro",
+        // inject rapx tool attr
         "-Zcrate-attr=feature(register_tool)",
         "-Zcrate-attr=register_tool(rapx)",
     ])


### PR DESCRIPTION
Demonstraction of deployment, especially on generated safety doc string:

https://os-checker.github.io/tag-std/pin_init/struct.ChainPinInit.html
![](https://github.com/user-attachments/assets/17dfa26b-fa8f-4e96-9832-29722c5ded81)

NOTE: to make deployment successful, "Github Action" source in Pages and "No restriction" of _Deployment branches and tags_ in Environment should be set:

<details><summary>Screenshots to set them up</summary>
<p>

![](https://github.com/user-attachments/assets/6aa8fd58-6504-4f63-abf1-9d8b5f2e0b9d)
![](https://github.com/user-attachments/assets/f717dcb7-80b3-4370-9b82-c33484a71a6d)


</p>
</details> 


**Once the pages are deployed, <https://Artisan-Lab.github.io/tag-std/pin_init/struct.ChainPinInit.html> should be identical as shown above.**

---

This PR also allows `use safety_macro` syntax by adding `--extern=safety_macro`  as direct dependency. [ref](https://doc.rust-lang.org/rustc/command-line-arguments.html#--extern-specify-where-an-external-library-is-located)


