### PR TITLE
safety-lib: support no_std by gating safety-parser behind std feature

### DIFF
--- a/safety-tool/Cargo.lock
+++ b/safety-tool/Cargo.lock
@@ -763,7 +763,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safety-lib"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "expect-test",
  "safety-macro",
@@ -772,14 +772,14 @@ dependencies = [
 
 [[package]]
 name = "safety-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "safety-parser",
 ]
 
 [[package]]
 name = "safety-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "safety-tool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "annotate-snippets",
  "assert_cmd",

--- a/safety-tool/safety-lib/Cargo.toml
+++ b/safety-tool/safety-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safety-lib"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Artisan-Lab <xuh@fudan.edu.cn>"]
 description = "A lib for using safety tags defined in tag-std"
@@ -10,7 +10,11 @@ readme = "README.md"
 
 [dependencies]
 safety-macro = { path = "../safety-macro", version = "0.2.0" }
-safety-parser = { path = "../safety-parser", version = "0.2.0" }
+safety-parser = { path = "../safety-parser", version = "0.2.0", optional = true }
+
+[features]
+default = []
+std = ["dep:safety-parser"]
 
 [dev-dependencies]
 expect-test = "1.5.1"

--- a/safety-tool/safety-lib/src/lib.rs
+++ b/safety-tool/safety-lib/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
 pub use safety_parser;
 
 /// Safety macros.

--- a/safety-tool/safety-lib/src/lib.rs
+++ b/safety-tool/safety-lib/src/lib.rs
@@ -5,3 +5,4 @@ pub use safety_parser;
 
 /// Safety macros.
 pub mod safety;
+pub use safety::*;

--- a/safety-tool/tests/basic/Cargo.lock
+++ b/safety-tool/tests/basic/Cargo.lock
@@ -29,22 +29,21 @@ dependencies = [
 
 [[package]]
 name = "safety-lib"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "safety-macro",
- "safety-parser",
 ]
 
 [[package]]
 name = "safety-macro"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "safety-parser",
 ]
 
 [[package]]
 name = "safety-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,6 +1,6 @@
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
-********* "proc_macro2" [Rlib] has reached 1060 instances *********
+********* "proc_macro2" [Rlib] has reached 1112 instances *********
 ********* "quote" [Rlib] has reached 506 instances *********
 ********* "syn" [Rlib] has reached 6925 instances *********
 ********* "safety_parser" [Rlib] has reached 976 instances *********


### PR DESCRIPTION
This helps to introduce `#[safety::precond::Property]` attributes in no-std crates, like asterinas and Rust for Linux.

Note: this requires a new release for safety-lib from v0.2.0 to v0.2.1.

e.g.

```toml
# The following means renaming safety-lib to safety as your dependency
safety = { version = "0.2.1", package = "safety-lib" }
```

```rust
// Since safety-lib is no std by its default feature, and safety is available as dependency crate name,
// we can directly write things like #[safety::Memo] or #[safety::precond::Align] 
// without importing the crate (i.e. `use safety`).

#[safety::Memo]
unsafe fn foo() {}

#[safety::precond::Align(...)]
unsafe fn bar() {}
```