### PR TITLE
fix error in std.json

### DIFF
--- a/data/std.json
+++ b/data/std.json
@@ -829,7 +829,7 @@
 
     "core::ptr::mut_ptr::as_ref": {
         "0": [
-            "!Null | ",
+            "Null | ",
             "ValidPtr2Ref"
         ]
     },


### PR DESCRIPTION
There is a wrong description in std.json: SPs about core::ptr::mut_ptr::as_ref, and already fix it