### PR TITLE
safety-parser: make `[package]` and tag args optional

### DIFF
--- a/pre-RFC.md
+++ b/pre-RFC.md
@@ -79,13 +79,15 @@ Here are some basic syntax examples:
 ```
 
 We can define the annotation language with context-free grammar as follows:
+
 ```text
 SafetyAnnotation => '#' '[' 'safety' '{' SPUnits '}' ']'
 SPUnits => SPUnit (';' SPUnit)*
-SPUnit => SPItem (',' SPItem)*
-SPItem => ID Args ':' Reasons
+SPUnit => SPItem (',' SPItem)* (':' Reasons)?
+SPItem => ID (Args)?
 ID => ([a-z][A-Z])+
-Args => ε | '(' Arg (, Arg)* ')'
+Args => '(' Arg (, Arg)* ')'
+Arg => expression
 Reasons => '"' Text '"'
 ```
 

--- a/safety-tool/assets/sp-core.toml
+++ b/safety-tool/assets/sp-core.toml
@@ -1,5 +1,4 @@
 package.name = "core"
-tool-version = "0.1.0"
 
 [tag.Alias]
 args = [ "p1", "p2" ]

--- a/safety-tool/assets/sp-rust-for-linux.toml
+++ b/safety-tool/assets/sp-rust-for-linux.toml
@@ -1,9 +1,4 @@
 package.name = "rfl"
-tool-version = "0.1.0"
 
 [tag.UserProperty]
-args = []
-desc = "desc"
-expr = ""
-url = ""
 

--- a/safety-tool/safety-parser/src/configuration.rs
+++ b/safety-tool/safety-parser/src/configuration.rs
@@ -12,7 +12,7 @@ pub type OptStr = Option<Box<str>>;
 
 #[derive(Debug, Deserialize)]
 pub struct Configuration {
-    pub package: Package,
+    pub package: Option<Package>,
     pub tag: IndexMap<Str, Tag>,
 }
 
@@ -29,13 +29,14 @@ impl Configuration {
 
 #[derive(Debug, Deserialize)]
 pub struct Package {
-    pub name: Box<str>,
+    pub name: Str,
     pub version: OptStr,
     pub crate_name: OptStr,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Tag {
+    #[serde(default)]
     pub args: Box<[Str]>,
     pub desc: OptStr,
     pub expr: OptStr,

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,10 +1,10 @@
-********* "build_script_build" [Executable] has reached 17 instances *********
+********* "equivalent" [Rlib] has reached 0 instances *********
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "ryu" [Rlib] has reached 76 instances *********
+********* "itoa" [Rlib] has reached 42 instances *********
+********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
-********* "itoa" [Rlib] has reached 42 instances *********
-********* "equivalent" [Rlib] has reached 0 instances *********
-********* "ryu" [Rlib] has reached 76 instances *********
 ********* "toml_writer" [Rlib] has reached 101 instances *********
 ********* "memchr" [Rlib] has reached 938 instances *********
 ********* "hashbrown" [Rlib] has reached 236 instances *********
@@ -21,7 +21,7 @@
 ********* "serde_json" [Rlib] has reached 1364 instances *********
 ********* "toml" [Rlib] has reached 2083 instances *********
 ********* "tinytemplate" [Rlib] has reached 542 instances *********
-********* "safety_parser" [Rlib] has reached 1791 instances *********
+********* "safety_parser" [Rlib] has reached 1798 instances *********
 ********* "safety_macro" [ProcMacro] has reached 76 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
 "test" ("src/lib.rs:9:1: 9:26")

--- a/safety-tool/tests/configuration.rs
+++ b/safety-tool/tests/configuration.rs
@@ -2,8 +2,7 @@ use expect_test::expect;
 use safety_parser::configuration::Configuration;
 
 const TOML: &str = r#"
-package.name = "core"
-tool-version = "0.1.0"
+[tag.A]
 
 [tag.ValidPtr]
 args = [ "p", "T", "len" ]


### PR DESCRIPTION
This should bump a minor version for safety-parser to be 0.3.1.