### PR TITLE
Fix: don't emit string literal quotes and add extra 2 newlines for each SP doc item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
   pull_request:
     branches:
+env:
+  # deploy demo doc
+  DOC: true
 
 jobs:
   build:
@@ -34,4 +37,28 @@ jobs:
       - name: Run Tests
         working-directory: safety-tool
         run: bash run.sh
+
+      - name: Upload static files as artifact
+        uses: actions/upload-pages-artifact@v3
+        if: env.DOC == 'true'
+        with:
+          path: safety-tool/tests/basic/target/doc/
+
+  # Deployment job
+  deploy:
+    if: env.DOC == 'true'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        if: runner.os == 'Linux' && runner.arch == 'X64' && github.ref == 'refs/heads/main'
+        uses: actions/deploy-pages@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,6 @@ jobs:
         if: true
         uses: actions/deploy-pages@v4
         with:
+          # doc-Linux-X64 or doc-Linux-ARM64
           artifact_name: doc-Linux-X64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    outputs:
+      doc: ${{ steps.set.outputs.doc }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,15 +40,19 @@ jobs:
         working-directory: safety-tool
         run: bash run.sh
 
+      - name: set DOC output # if: env.DOC won't work
+        id: doc
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        run: echo "DOC=${{ env.DOC }}" >> $GITHUB_OUTPUT
+
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
-        if: env.DOC == 'true'
+        if: steps.doc.outputs.DOC == 'true'
         with:
           path: safety-tool/tests/basic/target/doc/
 
   # Deployment job
   deploy:
-    if: env.DOC == 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -57,6 +63,7 @@ jobs:
       id-token: write   # to verify the deployment originates from an appropriate source
 
     needs: build
+    if: needs.build.outputs.DOC == 'true'
     steps:
       - name: Deploy to GitHub Pages
         if: runner.os == 'Linux' && runner.arch == 'X64' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # runner.os == 'Linux' && runner.arch == 'X64'
           name: doc-${{ runner.os }}-${{ runner.arch }}
           path: safety-tool/tests/basic/target/doc/
 
   # Deployment job
   deploy:
+    if: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -58,7 +58,6 @@ jobs:
     needs: build
     steps:
       - name: Deploy to GitHub Pages
-        if: true
         uses: actions/deploy-pages@v4
         with:
           # doc-Linux-X64 or doc-Linux-ARM64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
   pull_request:
     branches:
-env:
-  # deploy demo doc
-  DOC: true
 
 jobs:
   build:
@@ -40,15 +37,11 @@ jobs:
         working-directory: safety-tool
         run: bash run.sh
 
-      - name: set DOC output # if: env.DOC won't work
-        id: doc
-        if: runner.os == 'Linux' && runner.arch == 'X64'
-        run: echo "DOC=${{ env.DOC }}" >> $GITHUB_OUTPUT
-
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
-        if: steps.doc.outputs.DOC == 'true'
         with:
+          # runner.os == 'Linux' && runner.arch == 'X64'
+          name: doc-${{ runner.os }}-${{ runner.arch }}
           path: safety-tool/tests/basic/target/doc/
 
   # Deployment job
@@ -63,9 +56,10 @@ jobs:
       id-token: write   # to verify the deployment originates from an appropriate source
 
     needs: build
-    if: needs.build.outputs.DOC == 'true'
     steps:
       - name: Deploy to GitHub Pages
-        if: runner.os == 'Linux' && runner.arch == 'X64' && github.ref == 'refs/heads/main'
+        if: true
         uses: actions/deploy-pages@v4
+        with:
+          artifact_name: doc-Linux-X64
 

--- a/.github/workflows/rust-for-linux.yml
+++ b/.github/workflows/rust-for-linux.yml
@@ -9,14 +9,6 @@ env:
 
 jobs:
   check:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment-ubuntu-latest.outputs.page_url }}
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
@@ -47,10 +39,27 @@ jobs:
 
       - name: Upload static files as artifact
         uses: actions/upload-pages-artifact@v3
-        if: runner.os == 'Linux' && runner.arch == 'X64'
         with:
+          name: doc-${{ runner.os }}-${{ runner.arch }}
           path: linux/Documentation/output/rust/rustdoc/
 
+  # Deployment job
+  deploy:
+    if: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
-        if: runner.os == 'Linux' && runner.arch == 'X64' && github.ref == 'refs/heads/main'
         uses: actions/deploy-pages@v4
+        with:
+          # doc-Linux-X64 or doc-Linux-ARM64
+          artifact_name: doc-Linux-X64
+

--- a/safety-tool/assets/sp_demo.toml
+++ b/safety-tool/assets/sp_demo.toml
@@ -1,0 +1,3 @@
+[tag.RustdocLinkToItem]
+args = [ "item" ]
+desc = "[`{item}`]"

--- a/safety-tool/run.sh
+++ b/safety-tool/run.sh
@@ -37,7 +37,7 @@ popd
 
 # enable tag definitions
 rm $DATA_SQLITE3
-export SP_FILE=$PWD/assets/sp-core.toml
+export SP_DIR=$PWD/assets
 
 # Test basic demo
 pushd ./tests/basic

--- a/safety-tool/run.sh
+++ b/safety-tool/run.sh
@@ -52,3 +52,4 @@ PREFIX=$PWD/
 CARGO_TERM_PROGRESS_WHEN=never $CARGO_SAFETY_TOOL | sed "s#$PREFIX##g" | tee macro-expanded/cargo-safety-tool.txt
 cargo expand --lib >macro-expanded/lib.rs
 cargo expand --bin demo >macro-expanded/main.rs
+cargo doc --no-deps

--- a/safety-tool/safety-parser/src/safety/utils.rs
+++ b/safety-tool/safety-parser/src/safety/utils.rs
@@ -14,6 +14,7 @@ pub fn template(desc: &str, map: &IndexMap<&str, String>) -> String {
     template.add_template("", desc).unwrap();
     let mut doc = template.render("", map).unwrap();
     doc.push('\n'); // add extra newline
+    doc.push('\n'); // add extra newline
     doc
 }
 

--- a/safety-tool/safety-parser/src/safety/utils.rs
+++ b/safety-tool/safety-parser/src/safety/utils.rs
@@ -1,8 +1,12 @@
 use indexmap::IndexMap;
 
 pub fn expr_to_string(expr: &syn::Expr) -> String {
-    let tokens = quote::quote! { #expr };
-    tokens.to_string()
+    if let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(s), .. }) = expr {
+        s.value()
+    } else {
+        let tokens = quote::quote! { #expr };
+        tokens.to_string()
+    }
 }
 
 pub fn template(desc: &str, map: &IndexMap<&str, String>) -> String {

--- a/safety-tool/safety-parser/src/safety/utils.rs
+++ b/safety-tool/safety-parser/src/safety/utils.rs
@@ -12,7 +12,9 @@ pub fn expr_to_string(expr: &syn::Expr) -> String {
 pub fn template(desc: &str, map: &IndexMap<&str, String>) -> String {
     let mut template = tinytemplate::TinyTemplate::new();
     template.add_template("", desc).unwrap();
-    template.render("", map).unwrap()
+    let mut doc = template.render("", map).unwrap();
+    doc.push('\n'); // add extra newline
+    doc
 }
 
 #[test]

--- a/safety-tool/tests/basic/Cargo.lock
+++ b/safety-tool/tests/basic/Cargo.lock
@@ -70,14 +70,14 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safety-macro"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "safety-parser",
 ]
 
 [[package]]
 name = "safety-parser"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "indexmap",
  "proc-macro2",

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,10 +1,10 @@
 ********* "equivalent" [Rlib] has reached 0 instances *********
-********* "itoa" [Rlib] has reached 42 instances *********
-********* "unicode_ident" [Rlib] has reached 12 instances *********
-********* "build_script_build" [Executable] has reached 156 instances *********
-********* "build_script_build" [Executable] has reached 17 instances *********
-********* "ryu" [Rlib] has reached 76 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
+********* "ryu" [Rlib] has reached 76 instances *********
+********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "itoa" [Rlib] has reached 42 instances *********
+********* "build_script_build" [Executable] has reached 17 instances *********
+********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "toml_writer" [Rlib] has reached 101 instances *********
 ********* "memchr" [Rlib] has reached 938 instances *********
 ********* "hashbrown" [Rlib] has reached 236 instances *********
@@ -21,16 +21,16 @@
 ********* "serde_json" [Rlib] has reached 1364 instances *********
 ********* "toml" [Rlib] has reached 2083 instances *********
 ********* "tinytemplate" [Rlib] has reached 542 instances *********
-********* "safety_parser" [Rlib] has reached 1798 instances *********
+********* "safety_parser" [Rlib] has reached 1801 instances *********
 ********* "safety_macro" [ProcMacro] has reached 76 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
 "test" ("src/lib.rs:9:1: 9:26")
  => "#[rapx::inner(Unreachable)]\n"
 
 "MyStruct::get" ("src/lib.rs:30:5: 30:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"test\"))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"))]\n"
 
 ********* "demo" [Executable] has reached 18 instances *********
 "demo::MyStruct::get" ("src/lib.rs:30:5: 30:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"test\"))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"))]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,14 +1,14 @@
-********* "build_script_build" [Executable] has reached 17 instances *********
-********* "unicode_ident" [Rlib] has reached 12 instances *********
-********* "build_script_build" [Executable] has reached 71 instances *********
-********* "build_script_build" [Executable] has reached 156 instances *********
-********* "itoa" [Rlib] has reached 42 instances *********
-********* "ryu" [Rlib] has reached 76 instances *********
 ********* "equivalent" [Rlib] has reached 0 instances *********
+********* "itoa" [Rlib] has reached 42 instances *********
+********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "build_script_build" [Executable] has reached 156 instances *********
+********* "build_script_build" [Executable] has reached 17 instances *********
+********* "ryu" [Rlib] has reached 76 instances *********
+********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "toml_writer" [Rlib] has reached 101 instances *********
 ********* "memchr" [Rlib] has reached 938 instances *********
-********* "proc_macro2" [Rlib] has reached 1112 instances *********
 ********* "hashbrown" [Rlib] has reached 236 instances *********
+********* "proc_macro2" [Rlib] has reached 1112 instances *********
 ********* "quote" [Rlib] has reached 506 instances *********
 ********* "winnow" [Rlib] has reached 618 instances *********
 ********* "toml_parser" [Rlib] has reached 845 instances *********
@@ -27,10 +27,10 @@
 "test" ("src/lib.rs:9:1: 9:26")
  => "#[rapx::inner(Unreachable)]\n"
 
-"MyStruct::get" ("src/lib.rs:28:5: 28:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr))]\n"
+"MyStruct::get" ("src/lib.rs:30:5: 30:42")
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"test\"))]\n"
 
 ********* "demo" [Executable] has reached 18 instances *********
-"demo::MyStruct::get" ("src/lib.rs:28:5: 28:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr))]\n"
+"demo::MyStruct::get" ("src/lib.rs:30:5: 30:42")
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"test\"))]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,8 +1,8 @@
 ********* "equivalent" [Rlib] has reached 0 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
-********* "ryu" [Rlib] has reached 76 instances *********
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
 ********* "itoa" [Rlib] has reached 42 instances *********
+********* "ryu" [Rlib] has reached 76 instances *********
 ********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "toml_writer" [Rlib] has reached 101 instances *********

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -9,7 +9,7 @@ use std::prelude::rust_2024::*;
 extern crate std;
 use safety_macro::safety;
 #[rapx::inner(Unreachable)]
-#[doc = "* Unreachable: the current program point should not be reachable during execution\n"]
+#[doc = "* Unreachable: the current program point should not be reachable during execution\n\n"]
 pub unsafe fn test() -> ! {
     unsafe { std::intrinsics::unreachable() }
 }
@@ -28,11 +28,11 @@ impl MyStruct {
         Alias(self.ptr),
         RustdocLinkToItem("crate::test")
     )]
-    #[doc = "* Init: the memory range [self.ptr, self.ptr + sizeof(u8)*self.len] must be fully initialized for type T\n"]
-    #[doc = "* InBound: the pointer self.ptr and its offset up to sizeof(u8)*self.len must point to a single allocated object\n"]
-    #[doc = "* ValidNum: the value of self.len * sizeof(u8) must lie within the valid [0, isize :: MAX]\n"]
-    #[doc = "* Alias: self.ptr must not have other alias\n"]
-    #[doc = "* RustdocLinkToItem: [`crate::test`]\n"]
+    #[doc = "* Init: the memory range [self.ptr, self.ptr + sizeof(u8)*self.len] must be fully initialized for type T\n\n"]
+    #[doc = "* InBound: the pointer self.ptr and its offset up to sizeof(u8)*self.len must point to a single allocated object\n\n"]
+    #[doc = "* ValidNum: the value of self.len * sizeof(u8) must lie within the valid [0, isize :: MAX]\n\n"]
+    #[doc = "* Alias: self.ptr must not have other alias\n\n"]
+    #[doc = "* RustdocLinkToItem: [`crate::test`]\n\n"]
     /// correct link: [`crate::test`]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -9,7 +9,7 @@ use std::prelude::rust_2024::*;
 extern crate std;
 use safety_macro::safety;
 #[rapx::inner(Unreachable)]
-///* Unreachable: the current program point should not be reachable during execution
+#[doc = "* Unreachable: the current program point should not be reachable during execution\n"]
 pub unsafe fn test() -> ! {
     unsafe { std::intrinsics::unreachable() }
 }
@@ -26,14 +26,14 @@ impl MyStruct {
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
         Alias(self.ptr),
-        RustdocLinkToItem("test")
+        RustdocLinkToItem("crate::test")
     )]
-    ///* Init: the memory range [self.ptr, self.ptr + sizeof(u8)*self.len] must be fully initialized for type T
-    ///* InBound: the pointer self.ptr and its offset up to sizeof(u8)*self.len must point to a single allocated object
-    ///* ValidNum: the value of self.len * sizeof(u8) must lie within the valid [0, isize :: MAX]
-    ///* Alias: self.ptr must not have other alias
-    ///* RustdocLinkToItem: [`test`]
-    /// correct link: [`test`]
+    #[doc = "* Init: the memory range [self.ptr, self.ptr + sizeof(u8)*self.len] must be fully initialized for type T\n"]
+    #[doc = "* InBound: the pointer self.ptr and its offset up to sizeof(u8)*self.len must point to a single allocated object\n"]
+    #[doc = "* ValidNum: the value of self.len * sizeof(u8) must lie within the valid [0, isize :: MAX]\n"]
+    #[doc = "* Alias: self.ptr must not have other alias\n"]
+    #[doc = "* RustdocLinkToItem: [`crate::test`]\n"]
+    /// correct link: [`crate::test`]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -25,12 +25,15 @@ impl MyStruct {
         Init(self.ptr, u8, self.len),
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
-        Alias(self.ptr)
+        Alias(self.ptr),
+        RustdocLinkToItem("test")
     )]
     ///* Init: the memory range [self.ptr, self.ptr + sizeof(u8)*self.len] must be fully initialized for type T
     ///* InBound: the pointer self.ptr and its offset up to sizeof(u8)*self.len must point to a single allocated object
     ///* ValidNum: the value of self.len * sizeof(u8) must lie within the valid [0, isize :: MAX]
     ///* Alias: self.ptr must not have other alias
+    ///* RustdocLinkToItem: [`&quot;test&quot;`]
+    /// correct link: [`test`]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -32,7 +32,7 @@ impl MyStruct {
     ///* InBound: the pointer self.ptr and its offset up to sizeof(u8)*self.len must point to a single allocated object
     ///* ValidNum: the value of self.len * sizeof(u8) must lie within the valid [0, isize :: MAX]
     ///* Alias: self.ptr must not have other alias
-    ///* RustdocLinkToItem: [`&quot;test&quot;`]
+    ///* RustdocLinkToItem: [`test`]
     /// correct link: [`test`]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/macro-expanded/main.rs
+++ b/safety-tool/tests/basic/macro-expanded/main.rs
@@ -19,7 +19,7 @@ fn main() {
                 "{0:?}\n",
                 unsafe {
                     #[rapx::inner(
-                        Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used."
+                        Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem
                     )] ///This is from a valid Vec object.
                     ///* Init: the memory range [,  + sizeof()*] must be fully initialized for type T
                     ///This is from a valid Vec object.
@@ -28,6 +28,7 @@ fn main() {
                     ///* ValidNum: the value of  must lie within the valid
                     ///p is no longer used.
                     ///* Alias:  must not have other alias
+                    ///* RustdocLinkToItem: [``]
                     a.get()
                 },
             ),

--- a/safety-tool/tests/basic/macro-expanded/main.rs
+++ b/safety-tool/tests/basic/macro-expanded/main.rs
@@ -21,15 +21,14 @@ fn main() {
                     #[rapx::inner(
                         Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem
                     )] ///This is from a valid Vec object.
-                    ///* Init: the memory range [,  + sizeof()*] must be fully initialized for type T
+                    #[doc = "* Init: the memory range [,  + sizeof()*] must be fully initialized for type T\n"]
                     ///This is from a valid Vec object.
-                    ///* InBound: the pointer  and its offset up to sizeof()* must point to a single allocated object
+                    #[doc = "* InBound: the pointer  and its offset up to sizeof()* must point to a single allocated object\n"]
                     ///self.len is valid.
-                    ///* ValidNum: the value of  must lie within the valid
+                    #[doc = "* ValidNum: the value of  must lie within the valid \n"]
                     ///p is no longer used.
-                    ///* Alias:  must not have other alias
-                    ///* RustdocLinkToItem: [``]
-                    a.get()
+                    #[doc = "* Alias:  must not have other alias\n"]
+                    #[doc = "* RustdocLinkToItem: [``]\n"] a.get()
                 },
             ),
         );

--- a/safety-tool/tests/basic/macro-expanded/main.rs
+++ b/safety-tool/tests/basic/macro-expanded/main.rs
@@ -21,14 +21,14 @@ fn main() {
                     #[rapx::inner(
                         Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem
                     )] ///This is from a valid Vec object.
-                    #[doc = "* Init: the memory range [,  + sizeof()*] must be fully initialized for type T\n"]
+                    #[doc = "* Init: the memory range [,  + sizeof()*] must be fully initialized for type T\n\n"]
                     ///This is from a valid Vec object.
-                    #[doc = "* InBound: the pointer  and its offset up to sizeof()* must point to a single allocated object\n"]
+                    #[doc = "* InBound: the pointer  and its offset up to sizeof()* must point to a single allocated object\n\n"]
                     ///self.len is valid.
-                    #[doc = "* ValidNum: the value of  must lie within the valid \n"]
+                    #[doc = "* ValidNum: the value of  must lie within the valid \n\n"]
                     ///p is no longer used.
-                    #[doc = "* Alias:  must not have other alias\n"]
-                    #[doc = "* RustdocLinkToItem: [``]\n"] a.get()
+                    #[doc = "* Alias:  must not have other alias\n\n"]
+                    #[doc = "* RustdocLinkToItem: [``]\n\n"] a.get()
                 },
             ),
         );

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -19,11 +19,13 @@ impl MyStruct {
         MyStruct { ptr: p, len: l }
     }
 
+    /// correct link: [`test`]
     #[safety {
         Init(self.ptr, u8, self.len),
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
-        Alias(self.ptr)
+        Alias(self.ptr),
+        RustdocLinkToItem("test")
     }]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -19,13 +19,13 @@ impl MyStruct {
         MyStruct { ptr: p, len: l }
     }
 
-    /// correct link: [`test`]
+    /// correct link: [`crate::test`]
     #[safety {
         Init(self.ptr, u8, self.len),
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
         Alias(self.ptr),
-        RustdocLinkToItem("test")
+        RustdocLinkToItem("crate::test")
     }]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/src/main.rs
+++ b/safety-tool/tests/basic/src/main.rs
@@ -15,7 +15,8 @@ fn main() {
             Init: "This is from a valid Vec object.";
             InBound: "This is from a valid Vec object.";
             ValidNum: "self.len is valid.";
-            Alias: "p is no longer used."
+            Alias: "p is no longer used.";
+            RustdocLinkToItem
         }]
         a.get()
     });


### PR DESCRIPTION
```toml
[tag.RustdocLinkToItem]
args = [ "item" ]
desc = "[`{item}`]"
```

`RustdocLinkToItem("crate::test")` now generates

```rust
#[doc = "* RustdocLinkToItem: [`crate::test`]\n\n"]
```

intead of

```rust
#[doc = "* RustdocLinkToItem: [`&Quot; crate::test&Quot; `]"]
```