### PR TITLE
Feat: Support `any { SP1, SP2 }` tag

### DIFF
--- a/.github/rust-for-linux/check.sh
+++ b/.github/rust-for-linux/check.sh
@@ -26,11 +26,13 @@ rustup default $RUST_TOOLCHAIN
 export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib
 
 pushd safety-tool
+# Switch toolchain
+./gen_rust_toolchain_toml.rs rfl
 # Must enter safety-tool folder to respect rust toolchain to compile code.
-cargo install --path . --locked
+cargo install --path . --locked -Frfl
 # This should print `rustc 1.87.0 (17067e9ac 2025-05-09)`.
 safety-tool --version
-# generate bin and lib in target/safety-tool
+# Generate bin and lib in target/safety-tool
 safety-tool-rfl build-dev
 popd
 

--- a/safety-tool/.vscode/settings.json
+++ b/safety-tool/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "rust-analyzer.cargo.features": [
-    "asterinas"
+    "std"
   ]
 }

--- a/safety-tool/run.sh
+++ b/safety-tool/run.sh
@@ -14,7 +14,11 @@ export STOP_COMPILATION=1
 # ./run.sh -Fstd
 FEATURES=${1:-"std"}
 
+# Switch toolchain
 ./gen_rust_toolchain_toml.rs ${FEATURES}
+
+# Remove data.sqlite3 the cache
+rm -f target/data.sqlite3 tests/basic/data.sqlite3
 
 cargo fmt --check --all
 cargo clippy -F${FEATURES} --workspace -- -D clippy::all

--- a/safety-tool/rust-toolchain.toml
+++ b/safety-tool/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-02-01"
+channel = "nightly-2025-06-02"
 components = ["llvm-tools", "rustc-dev", "rust-src", "rust-analyzer", "rustfmt", "clippy"]

--- a/safety-tool/safety-parser/src/configuration.rs
+++ b/safety-tool/safety-parser/src/configuration.rs
@@ -164,6 +164,9 @@ pub fn crate_sp_paths() -> Option<Vec<String>> {
     None
 }
 
+/// `any` tag is denied in user's spec, and special in doc generation.
+pub const ANY: &str = "any";
+
 /// Data shared in `#[safety]` proc macro.
 #[derive(Debug)]
 struct Key {
@@ -195,7 +198,7 @@ static CACHE: LazyLock<Cache> = LazyLock::new(|| {
 
     for (config, path) in configs {
         for (name, tag) in config.tag {
-            if &*name == "any" {
+            if &*name == ANY {
                 panic!("`any` is a builtin tag. Please remove it from spec.");
             }
             if let Some(old) = cache.map.get(&name) {

--- a/safety-tool/safety-parser/src/configuration.rs
+++ b/safety-tool/safety-parser/src/configuration.rs
@@ -195,6 +195,9 @@ static CACHE: LazyLock<Cache> = LazyLock::new(|| {
 
     for (config, path) in configs {
         for (name, tag) in config.tag {
+            if &*name == "any" {
+                panic!("`any` is a builtin tag. Please remove it from spec.");
+            }
             if let Some(old) = cache.map.get(&name) {
                 panic!("Tag {name:?} has been defined: {old:?}");
             }

--- a/safety-tool/safety-parser/src/safety/mod.rs
+++ b/safety-tool/safety-parser/src/safety/mod.rs
@@ -217,7 +217,7 @@ impl Property {
     /// SPs in `any` tag. None means the tag is not `any` or empty args.
     pub fn args_in_any_tag(&self) -> Option<Vec<PropertiesAndReason>> {
         (self.tag.name() == ANY && !self.args.is_empty())
-            .then_some(utils::parse_args_in_any_tag(&self.args))
+            .then(|| utils::parse_args_in_any_tag(&self.args))
     }
 }
 

--- a/safety-tool/safety-parser/src/safety/mod.rs
+++ b/safety-tool/safety-parser/src/safety/mod.rs
@@ -79,6 +79,7 @@ impl Parse for PropertiesAndReason {
             if config_exists() {
                 tag.check_type();
             }
+            // FIXME: parse braces for `any { ... }`
             let sp = if input.peek(Paren) {
                 let content;
                 parenthesized!(content in input);
@@ -189,7 +190,7 @@ impl Property {
             let mut doc =
                 "Only one of the following properties requires being satisfied:\n".to_owned();
             // validate SPs in `any(SP1, SP2, ...)` exist
-            for prop in utils::validate_any(&self.args) {
+            for prop in utils::parse_args_in_any_tag(&self.args) {
                 doc.push_str(&prop.gen_sp_in_any_doc());
             }
             return Some(doc);
@@ -211,6 +212,12 @@ impl Property {
         }
 
         defined_tag.desc.as_deref().map(|desc| utils::template(desc, &map_defined_arg_input_arg))
+    }
+
+    /// SPs in `any` tag. None means the tag is not `any` or empty args.
+    pub fn args_in_any_tag(&self) -> Option<Vec<PropertiesAndReason>> {
+        (self.tag.name() == ANY && !self.args.is_empty())
+            .then_some(utils::parse_args_in_any_tag(&self.args))
     }
 }
 

--- a/safety-tool/safety-parser/src/safety/mod.rs
+++ b/safety-tool/safety-parser/src/safety/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     Str,
-    configuration::{TagType, config_exists, doc_option, get_tag},
+    configuration::{ANY, TagType, config_exists, doc_option, get_tag},
 };
 use indexmap::IndexMap;
 use proc_macro2::TokenStream;
@@ -144,6 +144,25 @@ impl PropertiesAndReason {
         ts
     }
 
+    fn gen_sp_in_any_doc(&self) -> String {
+        let mut doc = String::new();
+        let heading_tag = doc_option().heading_tag;
+
+        for tag in &self.tags {
+            let name = tag.tag.name();
+            let item = match (heading_tag, tag.gen_doc()) {
+                (true, None) => format!("    * {name}"),
+                (true, Some(desc)) => format!("    * {name}: {desc}"),
+                (false, None) => String::new(),
+                (false, Some(desc)) => format!("    * {desc}"),
+            };
+            doc.push_str(&item);
+            doc.push('\n');
+        }
+        doc.pop();
+        doc
+    }
+
     pub fn need_gen_doc(&self) -> bool {
         self.desc.is_some() || !self.tags.is_empty()
     }
@@ -161,7 +180,22 @@ impl Property {
     /// Generate `#[doc]` for this property from its desc string interpolation.
     /// None means SP is not defined with desc, thus nothing to generate.
     pub fn gen_doc(&self) -> Option<String> {
-        let defined_tag = get_tag(self.tag.name());
+        let name = self.tag.name();
+
+        if name == ANY {
+            if self.args.is_empty() {
+                return None;
+            }
+            let mut doc =
+                "Only one of the following properties requires being satisfied:\n".to_owned();
+            // validate SPs in `any(SP1, SP2, ...)` exist
+            for prop in utils::validate_any(&self.args) {
+                doc.push_str(&prop.gen_sp_in_any_doc());
+            }
+            return Some(doc);
+        }
+
+        let defined_tag = get_tag(name);
         // NOTE: this tolerates missing args, but position matters.
         let args_len = self.args.len().min(defined_tag.args.len());
 
@@ -225,6 +259,10 @@ impl TagNameType {
     /// Check if the tag in macro is wrongly specified.
     pub fn check_type(&self) {
         let (name, typ) = self.name_type();
+        if name == ANY {
+            // FIXME: check SP args here
+            return;
+        }
         let defined_types = &get_tag(name).types;
         if let Some(typ) = typ {
             assert!(

--- a/safety-tool/safety-parser/src/safety/utils.rs
+++ b/safety-tool/safety-parser/src/safety/utils.rs
@@ -1,3 +1,4 @@
+use super::PropertiesAndReason;
 use indexmap::IndexMap;
 use syn::{Expr, ExprLit, Lit};
 
@@ -8,6 +9,17 @@ pub fn expr_to_string(expr: &Expr) -> String {
         let tokens = quote::quote! { #expr };
         tokens.to_string()
     }
+}
+
+/// Each expr must be in the form of `SP(expr)`. Return `(SP string, &Tag)`.
+pub fn validate_any(args: &[Expr]) -> Vec<PropertiesAndReason> {
+    let mut v_sp = Vec::with_capacity(args.len());
+    for expr in args {
+        let prop: PropertiesAndReason = syn::parse_quote!(#expr);
+        prop.tags.iter().for_each(|t| t.tag.check_type());
+        v_sp.push(prop);
+    }
+    v_sp
 }
 
 pub fn template(desc: &str, map: &IndexMap<&str, String>) -> String {

--- a/safety-tool/safety-parser/src/safety/utils.rs
+++ b/safety-tool/safety-parser/src/safety/utils.rs
@@ -1,4 +1,5 @@
 use super::PropertiesAndReason;
+use crate::configuration::config_exists;
 use indexmap::IndexMap;
 use syn::{Expr, ExprLit, Lit};
 
@@ -12,11 +13,14 @@ pub fn expr_to_string(expr: &Expr) -> String {
 }
 
 /// Each expr must be in the form of `SP(expr)`. Return `(SP string, &Tag)`.
-pub fn validate_any(args: &[Expr]) -> Vec<PropertiesAndReason> {
+pub fn parse_args_in_any_tag(args: &[Expr]) -> Vec<PropertiesAndReason> {
+    let need_check = config_exists();
     let mut v_sp = Vec::with_capacity(args.len());
     for expr in args {
         let prop: PropertiesAndReason = syn::parse_quote!(#expr);
-        prop.tags.iter().for_each(|t| t.tag.check_type());
+        if need_check {
+            prop.tags.iter().for_each(|t| t.tag.check_type());
+        }
         v_sp.push(prop);
     }
     v_sp

--- a/safety-tool/src/bin/safety-tool/analyze_hir/db/data.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/db/data.rs
@@ -122,13 +122,15 @@ impl TagState {
             .vanilla
             .iter()
             .filter_map(|(sp, state)| (!*state).then_some(sp.as_str()))
-            .join(", ");
+            .format_with(", ", |sp, f| f(&format_args!("`{sp}`")))
+            .to_string();
         if !vanilla.is_empty() {
             v.push(vanilla);
         }
         for group in &self.group_of_any {
             if !group.values().any(|state| *state) {
-                v.push(group.keys().join(", "));
+                let any = group.keys().format_with(", or ", |sp, f| f(&format_args!("`{sp}`")));
+                v.push(any.to_string());
             }
         }
         v

--- a/safety-tool/src/bin/safety-tool/analyze_hir/db/data.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/db/data.rs
@@ -1,8 +1,9 @@
 use super::super::{HirFn, is_tool_attr};
+use itertools::Itertools;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::{Attribute, HirId, def_id::DefId};
 use rustc_middle::ty::TyCtxt;
-use safety_parser::safety::parse_attr_and_get_properties;
+use safety_parser::safety::{Property as SP, parse_attr_and_get_properties};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -79,13 +80,94 @@ fn attribute_to_string(tcx: TyCtxt<'_>, attr: &rustc_hir::Attribute) -> String {
     rustc_hir_pretty::attribute_to_string(&tcx, attr).trim().to_owned()
 }
 
-pub type TagsState = FxIndexMap<Property, bool>;
+#[derive(Debug, Default)]
+pub struct TagState {
+    /// Each tag must be discharged.
+    vanilla: FxIndexMap<Property, bool>,
+    /// Any one of the tags must be discharged. `any` tag can be specified multiple times.
+    group_of_any: Vec<FxIndexMap<Property, bool>>,
+}
+
+impl TagState {
+    fn clear(&mut self) {
+        self.vanilla.clear();
+        self.group_of_any.clear();
+    }
+
+    fn refresh(&mut self, props: &Properties) {
+        self.clear();
+        self.vanilla.extend(props.vanilla.iter().map(|p| (p.clone(), false)));
+        self.group_of_any.extend(
+            props.group_of_any.iter().map(|v| v.iter().map(|p| (p.clone(), false)).collect()),
+        );
+    }
+
+    pub fn discharge(&mut self, prop: &Property) {
+        if let Some(state) = self.vanilla.get_mut(prop) {
+            assert!(!*state, "{prop:?} has already been discharged");
+            *state = true;
+        } else {
+            for group in &mut self.group_of_any {
+                if let Some(state) = group.get_mut(prop) {
+                    assert!(!*state, "{prop:?} has already been discharged");
+                    *state = true;
+                }
+            }
+        }
+    }
+
+    pub fn undischarged(&self) -> Vec<String> {
+        let mut v = Vec::new();
+        let vanilla = self
+            .vanilla
+            .iter()
+            .filter_map(|(sp, state)| (!*state).then_some(sp.as_str()))
+            .join(", ");
+        if !vanilla.is_empty() {
+            v.push(vanilla);
+        }
+        for group in &self.group_of_any {
+            if !group.values().any(|state| *state) {
+                v.push(group.keys().join(", "));
+            }
+        }
+        v
+    }
+}
+
+#[derive(Debug, Default)]
+struct Properties {
+    vanilla: Vec<Property>,
+    group_of_any: Vec<Box<[Property]>>,
+}
+
+impl Properties {
+    fn push_attr(&mut self, attr: &str) {
+        let props = &*parse_attr_and_get_properties(attr);
+
+        // Usually tags are vanilla, so reserve enough sapce.
+        let cap = props.iter().map(|prop| prop.tags.len()).sum();
+        self.vanilla.reserve(cap);
+
+        for prop in props {
+            for tag in &*prop.tags {
+                if let Some(v_sp) = tag.args_in_any_tag() {
+                    // Push SPs in `any`
+                    let iter = v_sp.iter().flat_map(|p| p.tags.iter().map(to_prop));
+                    self.group_of_any.push(iter.collect());
+                } else {
+                    self.vanilla.push(to_prop(tag));
+                }
+            }
+        }
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct ToolAttrs {
-    map: FxIndexMap<PrimaryKey, Box<[Property]>>,
+    map: FxIndexMap<PrimaryKey, Properties>,
     /// State of safety tags shows if thet are discharged.
-    tagged: TagsState,
+    tagged: TagState,
 }
 
 impl ToolAttrs {
@@ -95,24 +177,23 @@ impl ToolAttrs {
                 .iter()
                 .filter(|d| !d.func.tool_attrs.is_empty())
                 .map(|d| {
-                    let mut v = Vec::with_capacity(d.func.tool_attrs.len());
-                    d.func.tool_attrs.iter().for_each(|s| push_properties(s, &mut v));
-                    (d.hash, v.into_boxed_slice())
+                    let mut props = Properties::default();
+                    d.func.tool_attrs.iter().for_each(|s| props.push_attr(s));
+                    (d.hash, props)
                 })
                 .collect(),
-            tagged: FxIndexMap::default(),
+            tagged: Default::default(),
         }
     }
 
-    pub fn get_tags(&mut self, def_id: DefId, tcx: TyCtxt) -> Option<&mut TagsState> {
+    pub fn get_tags(&mut self, def_id: DefId, tcx: TyCtxt) -> Option<&mut TagState> {
         let key = PrimaryKey::new(def_id, tcx);
         self.get_tags_via_key(key)
     }
 
-    fn get_tags_via_key(&mut self, key: PrimaryKey) -> Option<&mut TagsState> {
-        let properties = self.map.get(&key)?;
-        self.tagged.clear();
-        self.tagged.extend(properties.iter().map(|p| (p.clone(), false)));
+    fn get_tags_via_key(&mut self, key: PrimaryKey) -> Option<&mut TagState> {
+        let props = self.map.get(&key)?;
+        self.tagged.refresh(props);
         Some(&mut self.tagged)
     }
 }
@@ -159,4 +240,8 @@ fn push_properties(s: &str, v: &mut Vec<Property>) {
             v.push(Property { property: tag.tag.name().into() });
         }
     }
+}
+
+fn to_prop(sp: &SP) -> Property {
+    Property { property: sp.tag.name().into() }
 }

--- a/safety-tool/src/bin/safety-tool/analyze_hir/db/mod.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/db/mod.rs
@@ -2,7 +2,7 @@ mod storage;
 pub use storage::Database;
 
 mod data;
-pub use data::{Data, Func, PrimaryKey, Property, ToolAttrs};
+pub use data::{Data, Func, PrimaryKey, Property, TagState, ToolAttrs};
 
 pub fn get_all_tool_attrs(iter: impl IntoIterator<Item = Data>) -> crate::Result<ToolAttrs> {
     // Recommend setting the DATA_SQLITE3 environment variable to an absolute path.

--- a/safety-tool/src/bin/safety-tool/analyze_hir/visit.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/visit.rs
@@ -83,11 +83,15 @@ fn check_tag_state(
     hir_id: HirId,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let undischarged = tag_state.undischarged().join("\n");
-    if !undischarged.is_empty() {
+    let undischarged = tag_state.undischarged();
+    let len = undischarged.len();
+    let undischarged_str = undischarged.join("\n");
+    if len != 0 {
         let span_node = hir_span(hir_id, tcx);
         let span_body = tcx.source_span(hir_id.owner);
-        let title = format!("Tags are not discharged:\n{undischarged}");
+        let newline = if len == 1 { " " } else { "\n" };
+        let plural = if undischarged_str.matches(',').count() == 0 { "Tag is" } else { "Tags are" };
+        let title = format!("{plural} not discharged:{newline}{undischarged_str}");
 
         let anno_call =
             Level::Error.span(anno_span(span_body, span_node)).label("For this unsafe call.");

--- a/safety-tool/src/bin/safety-tool/analyze_hir/visit.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/visit.rs
@@ -43,11 +43,11 @@ impl Call {
 
             let properties = Property::new_with_hir_id(hir_id, tcx);
 
-            for tag in &properties {
-                tag_state.discharge(tag);
-            }
             let is_empty = properties.is_empty();
             if !is_empty {
+                for tag in &properties {
+                    tag_state.discharge(tag);
+                }
                 // only checks if Safety tags exist
                 check_tag_state(tcx, src_map, tag_state, hir_id, diagnostics);
             }
@@ -85,8 +85,8 @@ fn check_tag_state(
 ) {
     let undischarged = tag_state.undischarged();
     let len = undischarged.len();
-    let undischarged_str = undischarged.join("\n");
     if len != 0 {
+        let undischarged_str = undischarged.join("\n");
         let span_node = hir_span(hir_id, tcx);
         let span_body = tcx.source_span(hir_id.owner);
         let newline = if len == 1 { " " } else { "\n" };

--- a/safety-tool/src/bin/safety-tool/analyze_hir/visit.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/visit.rs
@@ -1,10 +1,10 @@
+use crate::analyze_hir::db::TagState;
+
 use super::{
     db::{Property, ToolAttrs},
     diagnostic::Diagnostic,
 };
 use annotate_snippets::*;
-use itertools::Itertools;
-use rustc_data_structures::fx::FxIndexMap;
 use rustc_hir::{
     def::{DefKind, Res},
     def_id::DefId,
@@ -32,11 +32,11 @@ impl Call {
         tool_attrs: &mut ToolAttrs,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
-        let Some(tags_state) = tool_attrs.get_tags(self.def_id, tcx) else {
+        let Some(tag_state) = tool_attrs.get_tags(self.def_id, tcx) else {
             // No tool attrs to be checked.
             return;
         };
-        debug!(?tags_state);
+        debug!(?tag_state);
 
         let mut check = |hir_id: HirId| {
             debug!(?hir_id, ?fn_hir_id);
@@ -44,23 +44,12 @@ impl Call {
             let properties = Property::new_with_hir_id(hir_id, tcx);
 
             for tag in &properties {
-                if let Some(state) = tags_state.get_mut(tag) {
-                    assert!(!*state, "{tag:?} has already been discharged");
-                    *state = true;
-                } else {
-                    // FIXME: a parent is allowed to have extra tags than
-                    // the current call, so is invalid_tag check necessary?
-                    //
-                    // let tags: Vec<_> = tags_state.keys().collect();
-                    // let title = format!("Tag {tag:?} doesn't belong to tags {tags:?}");
-                    // let render = gen_diagnosis_for_a_line(hir_span(hir_id, tcx), src_map, &title);
-                    // diagnostics.push(Diagnostic::invalid_tag(render));
-                }
+                tag_state.discharge(tag);
             }
             let is_empty = properties.is_empty();
             if !is_empty {
                 // only checks if Safety tags exist
-                check_tag_state(tcx, src_map, tags_state, hir_id, diagnostics);
+                check_tag_state(tcx, src_map, tag_state, hir_id, diagnostics);
             }
             is_empty
         };
@@ -83,32 +72,22 @@ impl Call {
         }
 
         // make sure Safety tags are all discharged
-        check_tag_state(tcx, src_map, tags_state, self.hir_id, diagnostics);
+        check_tag_state(tcx, src_map, tag_state, self.hir_id, diagnostics);
     }
 }
 
 fn check_tag_state(
     tcx: TyCtxt,
     src_map: &SourceMap,
-    tags_state: &mut FxIndexMap<Property, bool>,
+    tag_state: &mut TagState,
     hir_id: HirId,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let mut n = 0;
-    let undischarged = tags_state
-        .iter()
-        .filter(|(_, state)| !*state)
-        .map(|(tag, _)| {
-            n += 1;
-            tag.as_str()
-        })
-        .format_with(", ", |tag, f| f(&format_args!("`{tag}`")))
-        .to_string();
-    if n != 0 {
+    let undischarged = tag_state.undischarged().join("\n");
+    if !undischarged.is_empty() {
         let span_node = hir_span(hir_id, tcx);
         let span_body = tcx.source_span(hir_id.owner);
-        let is = if n == 1 { "is" } else { "are" };
-        let title = format!("{undischarged} {is} not discharged");
+        let title = format!("Tags are not discharged:\n{undischarged}");
 
         let anno_call =
             Level::Error.span(anno_span(span_body, span_node)).label("For this unsafe call.");
@@ -139,17 +118,6 @@ fn gen_diagnosis_for_a_func(
     let msg = Level::Error.title(title).snippet(snippet.annotation(anno));
     Renderer::styled().render(msg).to_string().into()
 }
-
-// fn gen_diagnosis_for_a_line(span: Span, src_map: &SourceMap, title: &str) -> Box<str> {
-//     let src = src_map.span_to_snippet(span).unwrap();
-//     let file_and_line = src_map.lookup_line(span.lo()).unwrap();
-//     let line_start = file_and_line.line + 1; // adjust to starting from 1
-//     let origin = file_and_line.sf.name.prefer_local().to_string_lossy();
-//     let snippet = Snippet::source(&src).line_start(line_start).origin(&origin).fold(true);
-//
-//     let msg = Level::Error.title(title).snippet(snippet);
-//     Renderer::styled().render(msg).to_string().into()
-// }
 
 fn anno_span(span_body: Span, span_node: Span) -> Range<usize> {
     let body_lo = span_body.lo().0;

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,7 +1,7 @@
 ********* "equivalent" [Rlib] has reached 0 instances *********
 ********* "build_script_build" [Executable] has reached 17 instances *********
-********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "itoa" [Rlib] has reached 42 instances *********
 ********* "ryu" [Rlib] has reached 76 instances *********
@@ -28,5 +28,9 @@
  => "#[rapx::inner(Unreachable)]\n"
 
 "MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Init, InBound))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Deref, Allocated))]\n"
+
+********* "demo" [Executable] has reached 18 instances *********
+"demo::MyStruct::get" ("src/lib.rs:31:5: 31:42")
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Deref, Allocated))]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,7 +1,7 @@
-********* "equivalent" [Rlib] has reached 0 instances *********
 ********* "build_script_build" [Executable] has reached 17 instances *********
-********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "equivalent" [Rlib] has reached 0 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
+********* "unicode_ident" [Rlib] has reached 12 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "itoa" [Rlib] has reached 42 instances *********
 ********* "ryu" [Rlib] has reached 76 instances *********
@@ -28,9 +28,9 @@
  => "#[rapx::inner(Unreachable)]\n"
 
 "MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Deref, Allocated))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"),\nany(Deref(self.ptr, u8, 1), Alive(self.ptr, _)))]\n"
 
 ********* "demo" [Executable] has reached 18 instances *********
 "demo::MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Deref, Allocated))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"),\nany(Deref(self.ptr, u8, 1), Alive(self.ptr, _)))]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,6 +1,6 @@
 ********* "equivalent" [Rlib] has reached 0 instances *********
-********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
+********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "itoa" [Rlib] has reached 42 instances *********
@@ -28,9 +28,9 @@
  => "#[rapx::inner(Unreachable)]\n"
 
 "MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"),\nany(Deref(self.ptr, u8, 1), Alive(self.ptr, _)))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any\n{ Deref(self.ptr, u8, 1), Alive(self.ptr, _) })]\n"
 
 ********* "demo" [Executable] has reached 18 instances *********
 "demo::MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"),\nany(Deref(self.ptr, u8, 1), Alive(self.ptr, _)))]\n"
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any\n{ Deref(self.ptr, u8, 1), Alive(self.ptr, _) })]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,5 +1,5 @@
-********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "equivalent" [Rlib] has reached 0 instances *********
+********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
@@ -21,7 +21,7 @@
 ********* "serde_json" [Rlib] has reached 1437 instances *********
 ********* "toml" [Rlib] has reached 2034 instances *********
 ********* "tinytemplate" [Rlib] has reached 550 instances *********
-********* "safety_parser" [Rlib] has reached 2281 instances *********
+********* "safety_parser" [Rlib] has reached 2285 instances *********
 ********* "safety_macro" [ProcMacro] has reached 164 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
 "test" ("src/lib.rs:9:1: 9:26")

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,36 +1,36 @@
 ********* "equivalent" [Rlib] has reached 0 instances *********
-********* "ryu" [Rlib] has reached 76 instances *********
-********* "toml_writer" [Rlib] has reached 101 instances *********
-********* "build_script_build" [Executable] has reached 17 instances *********
-********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "unicode_ident" [Rlib] has reached 12 instances *********
 ********* "build_script_build" [Executable] has reached 156 instances *********
+********* "build_script_build" [Executable] has reached 17 instances *********
+********* "build_script_build" [Executable] has reached 71 instances *********
 ********* "itoa" [Rlib] has reached 42 instances *********
-********* "memchr" [Rlib] has reached 938 instances *********
-********* "hashbrown" [Rlib] has reached 236 instances *********
-********* "proc_macro2" [Rlib] has reached 1112 instances *********
+********* "ryu" [Rlib] has reached 76 instances *********
+********* "toml_writer" [Rlib] has reached 101 instances *********
+********* "memchr" [Rlib] has reached 752 instances *********
+********* "hashbrown" [Rlib] has reached 241 instances *********
+********* "proc_macro2" [Rlib] has reached 1060 instances *********
 ********* "quote" [Rlib] has reached 506 instances *********
 ********* "winnow" [Rlib] has reached 618 instances *********
 ********* "toml_parser" [Rlib] has reached 845 instances *********
 ********* "syn" [Rlib] has reached 6925 instances *********
-********* "serde_derive" [ProcMacro] has reached 3170 instances *********
-********* "serde" [Rlib] has reached 390 instances *********
+********* "serde_derive" [ProcMacro] has reached 3178 instances *********
+********* "serde" [Rlib] has reached 326 instances *********
 ********* "serde_spanned" [Rlib] has reached 21 instances *********
 ********* "toml_datetime" [Rlib] has reached 326 instances *********
-********* "indexmap" [Rlib] has reached 128 instances *********
-********* "serde_json" [Rlib] has reached 1364 instances *********
-********* "toml" [Rlib] has reached 2083 instances *********
-********* "tinytemplate" [Rlib] has reached 542 instances *********
-********* "safety_parser" [Rlib] has reached 2242 instances *********
+********* "indexmap" [Rlib] has reached 129 instances *********
+********* "serde_json" [Rlib] has reached 1437 instances *********
+********* "toml" [Rlib] has reached 2034 instances *********
+********* "tinytemplate" [Rlib] has reached 550 instances *********
+********* "safety_parser" [Rlib] has reached 2278 instances *********
 ********* "safety_macro" [ProcMacro] has reached 164 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
-"test" ("src/lib.rs:9:1: 9:26")
+"test" ("src/lib.rs:10:1: 10:26")
  => "#[rapx::inner(Unreachable)]\n"
 
-"MyStruct::get" ("src/lib.rs:30:5: 30:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"))]\n"
+"MyStruct::get" ("src/lib.rs:32:5: 32:42")
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Init, InBound))]\n"
 
 ********* "demo" [Executable] has reached 18 instances *********
-"demo::MyStruct::get" ("src/lib.rs:30:5: 30:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"))]\n"
+"demo::MyStruct::get" ("src/lib.rs:32:5: 32:42")
+ => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Init, InBound))]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -1,8 +1,8 @@
 ********* "equivalent" [Rlib] has reached 0 instances *********
-********* "unicode_ident" [Rlib] has reached 12 instances *********
-********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "build_script_build" [Executable] has reached 17 instances *********
 ********* "build_script_build" [Executable] has reached 71 instances *********
+********* "unicode_ident" [Rlib] has reached 12 instances *********
+********* "build_script_build" [Executable] has reached 156 instances *********
 ********* "itoa" [Rlib] has reached 42 instances *********
 ********* "ryu" [Rlib] has reached 76 instances *********
 ********* "toml_writer" [Rlib] has reached 101 instances *********
@@ -21,16 +21,12 @@
 ********* "serde_json" [Rlib] has reached 1437 instances *********
 ********* "toml" [Rlib] has reached 2034 instances *********
 ********* "tinytemplate" [Rlib] has reached 550 instances *********
-********* "safety_parser" [Rlib] has reached 2278 instances *********
+********* "safety_parser" [Rlib] has reached 2281 instances *********
 ********* "safety_macro" [ProcMacro] has reached 164 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
-"test" ("src/lib.rs:10:1: 10:26")
+"test" ("src/lib.rs:9:1: 9:26")
  => "#[rapx::inner(Unreachable)]\n"
 
-"MyStruct::get" ("src/lib.rs:32:5: 32:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Init, InBound))]\n"
-
-********* "demo" [Executable] has reached 18 instances *********
-"demo::MyStruct::get" ("src/lib.rs:32:5: 32:42")
+"MyStruct::get" ("src/lib.rs:31:5: 31:42")
  => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any(Init, InBound))]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -30,7 +30,7 @@ impl MyStruct {
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
         Alias(self.ptr),
         RustdocLinkToItem("crate::test"),
-        any(Deref, Allocated)
+        any(Deref(self.ptr, u8, 1), Alive(self.ptr, _))
     )]
     /// correct link: [`crate::test`]
     /**# Safety
@@ -41,7 +41,7 @@ impl MyStruct {
     #[doc = "* ValidNum: the value of `self.len * sizeof(u8)` must lie within the valid `[0, isize :: MAX]`\n\n"]
     #[doc = "* Alias: `self.ptr` must not have other alias\n\n"]
     #[doc = "* RustdocLinkToItem: [`crate::test`]\n\n"]
-    #[doc = "* any: Only one of the following properties requires being satisfied:\n    * Deref: pointer `` must be dereferencable in the `sizeof()*` memory from it\n\n    * Allocated: the memory range `[,  + sizeof()*)` must be allocated by allocator ``\n\n"]
+    #[doc = "* any: Only one of the following properties requires being satisfied:\n    * Deref: pointer `self.ptr` must be dereferencable in the `sizeof(u8)*1` memory from it\n\n    * Alive: the reference of `self.ptr` must outlive the lifetime `_`\n\n"]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -30,7 +30,8 @@ impl MyStruct {
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
         Alias(self.ptr),
         RustdocLinkToItem("crate::test"),
-        any(Deref(self.ptr, u8, 1), Alive(self.ptr, _))
+        any{Deref(self.ptr, u8, 1),
+        Alive(self.ptr, _)}
     )]
     /// correct link: [`crate::test`]
     /**# Safety

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -7,7 +7,6 @@
 use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
-extern crate safety_macro;
 use safety_macro::safety;
 #[rapx::inner(Unreachable)]
 /**# Safety
@@ -31,7 +30,7 @@ impl MyStruct {
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
         Alias(self.ptr),
         RustdocLinkToItem("crate::test"),
-        any(Init, InBound)
+        any(Deref, Allocated)
     )]
     /// correct link: [`crate::test`]
     /**# Safety
@@ -42,7 +41,7 @@ impl MyStruct {
     #[doc = "* ValidNum: the value of `self.len * sizeof(u8)` must lie within the valid `[0, isize :: MAX]`\n\n"]
     #[doc = "* Alias: `self.ptr` must not have other alias\n\n"]
     #[doc = "* RustdocLinkToItem: [`crate::test`]\n\n"]
-    #[doc = "* any: Only one of the following properties requires being satisfied:\n    * Init: the memory range `[,  + sizeof()*]` must be fully initialized for type ``\n\n    * InBound: the pointer `` and its offset up to `sizeof()*` must point to a single allocated object\n\n"]
+    #[doc = "* any: Only one of the following properties requires being satisfied:\n    * Deref: pointer `` must be dereferencable in the `sizeof()*` memory from it\n\n    * Allocated: the memory range `[,  + sizeof()*)` must be allocated by allocator ``\n\n"]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -7,6 +7,7 @@
 use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
+extern crate safety_macro;
 use safety_macro::safety;
 #[rapx::inner(Unreachable)]
 /**# Safety
@@ -29,7 +30,8 @@ impl MyStruct {
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),
         Alias(self.ptr),
-        RustdocLinkToItem("crate::test")
+        RustdocLinkToItem("crate::test"),
+        any(Init, InBound)
     )]
     /// correct link: [`crate::test`]
     /**# Safety
@@ -40,6 +42,7 @@ impl MyStruct {
     #[doc = "* ValidNum: the value of `self.len * sizeof(u8)` must lie within the valid `[0, isize :: MAX]`\n\n"]
     #[doc = "* Alias: `self.ptr` must not have other alias\n\n"]
     #[doc = "* RustdocLinkToItem: [`crate::test`]\n\n"]
+    #[doc = "* any: Only one of the following properties requires being satisfied:\n    * Init: the memory range `[,  + sizeof()*]` must be fully initialized for type ``\n\n    * InBound: the pointer `` and its offset up to `sizeof()*` must point to a single allocated object\n\n"]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
     }

--- a/safety-tool/tests/basic/macro-expanded/main.rs
+++ b/safety-tool/tests/basic/macro-expanded/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let a = MyStruct::from(p, l);
     #[rapx::inner(
         Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem,
-        Allocated
+        Alive
     )]
     let val = unsafe { a.get() };
     {

--- a/safety-tool/tests/basic/macro-expanded/main.rs
+++ b/safety-tool/tests/basic/macro-expanded/main.rs
@@ -13,16 +13,12 @@ use safety_macro::safety;
 fn main() {
     let (p, l, _c) = Vec::new().into_raw_parts();
     let a = MyStruct::from(p, l);
+    #[rapx::inner(
+        Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem,
+        Allocated
+    )]
+    let val = unsafe { a.get() };
     {
-        ::std::io::_print(
-            format_args!(
-                "{0:?}\n",
-                unsafe {
-                    #[rapx::inner(
-                        Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem
-                    )] a.get()
-                },
-            ),
-        );
+        ::std::io::_print(format_args!("{0:?}\n", val));
     };
 }

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -26,7 +26,7 @@ impl MyStruct {
         ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
         Alias(self.ptr),
         RustdocLinkToItem("crate::test"),
-        any ( Init, InBound )
+        any ( Deref, Allocated )
     }]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -26,7 +26,7 @@ impl MyStruct {
         ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
         Alias(self.ptr),
         RustdocLinkToItem("crate::test"),
-        any ( Deref(self.ptr, u8, 1), Alive(self.ptr, _) )
+        any { Deref(self.ptr, u8, 1), Alive(self.ptr, _) }
     }]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -26,7 +26,7 @@ impl MyStruct {
         ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
         Alias(self.ptr),
         RustdocLinkToItem("crate::test"),
-        any ( Deref, Allocated )
+        any ( Deref(self.ptr, u8, 1), Alive(self.ptr, _) )
     }]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
 #![feature(core_intrinsics)]
 
+extern crate safety_macro;
 use safety_macro::safety;
 
 #[safety{ Unreachable }]
@@ -25,7 +26,8 @@ impl MyStruct {
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0,isize::MAX]),
         Alias(self.ptr),
-        RustdocLinkToItem("crate::test")
+        RustdocLinkToItem("crate::test"),
+        any ( Init, InBound )
     }]
     pub unsafe fn get(&self) -> &mut [u8] {
         unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }

--- a/safety-tool/tests/basic/src/lib.rs
+++ b/safety-tool/tests/basic/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::missing_safety_doc, clippy::mut_from_ref, internal_features)]
 #![feature(core_intrinsics)]
 
-extern crate safety_macro;
 use safety_macro::safety;
 
 #[safety{ Unreachable }]

--- a/safety-tool/tests/basic/src/main.rs
+++ b/safety-tool/tests/basic/src/main.rs
@@ -10,14 +10,14 @@ use safety_macro::safety;
 fn main() {
     let (p, l, _c) = Vec::new().into_raw_parts();
     let a = MyStruct::from(p, l);
-    println!("{:?}", unsafe {
-        #[safety {
-            Init: "This is from a valid Vec object.";
-            InBound: "This is from a valid Vec object.";
-            ValidNum: "self.len is valid.";
-            Alias: "p is no longer used.";
-            RustdocLinkToItem
-        }]
-        a.get()
-    });
+    #[safety {
+        Init: "This is from a valid Vec object.";
+        InBound: "This is from a valid Vec object.";
+        ValidNum: "self.len is valid.";
+        Alias: "p is no longer used.";
+        RustdocLinkToItem,
+        Allocated
+    }]
+    let val = unsafe { a.get() };
+    println!("{val:?}");
 }

--- a/safety-tool/tests/basic/src/main.rs
+++ b/safety-tool/tests/basic/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
         ValidNum: "self.len is valid.";
         Alias: "p is no longer used.";
         RustdocLinkToItem,
-        Allocated
+        Alive
     }]
     let val = unsafe { a.get() };
     println!("{val:?}");

--- a/safety-tool/tests/snapshots/any_err.txt
+++ b/safety-tool/tests/snapshots/any_err.txt
@@ -1,0 +1,12 @@
+stdout=
+
+stderr=
+[1m[91merror[0m: [1mTags are not discharged: `SP1`, or `SP2`[0m
+ [1m[94m-->[0m ./tests/snippets/any_err.rs:7:14
+  [1m[94m|[0m
+[1m[94m7 |[0m     unsafe { call() };
+  [1m[94m|[0m              [1m[91m^^^^[0m [1m[91mFor this unsafe call.[0m
+  [1m[94m|[0m
+
+[1m[31mTotal counts of diagnostics from safety-tool: {MissingDischarges: 1}[0m
+

--- a/safety-tool/tests/snapshots/any_err_2.txt
+++ b/safety-tool/tests/snapshots/any_err_2.txt
@@ -8,12 +8,5 @@ stderr=
   [1m[94m|[0m         [1m[91m^^^^^^[0m [1m[91mFor this unsafe call.[0m
   [1m[94m|[0m
 
-[1m[91merror[0m: [1mTags are not discharged: `SP3`, or `SP4`[0m
- [1m[94m-->[0m ./tests/snippets/any_err_2.rs:9:9
-  [1m[94m|[0m
-[1m[94m9 |[0m         call()
-  [1m[94m|[0m         [1m[91m^^^^[0m [1m[91mFor this unsafe call.[0m
-  [1m[94m|[0m
-
-[1m[31mTotal counts of diagnostics from safety-tool: {MissingDischarges: 2}[0m
+[1m[31mTotal counts of diagnostics from safety-tool: {MissingDischarges: 1}[0m
 

--- a/safety-tool/tests/snapshots/any_err_2.txt
+++ b/safety-tool/tests/snapshots/any_err_2.txt
@@ -1,0 +1,19 @@
+stdout=
+
+stderr=
+[1m[91merror[0m: [1mTags are not discharged: `SP3`, or `SP4`[0m
+ [1m[94m-->[0m ./tests/snippets/any_err_2.rs:9:9
+  [1m[94m|[0m
+[1m[94m9 |[0m         call()
+  [1m[94m|[0m         [1m[91m^^^^^^[0m [1m[91mFor this unsafe call.[0m
+  [1m[94m|[0m
+
+[1m[91merror[0m: [1mTags are not discharged: `SP3`, or `SP4`[0m
+ [1m[94m-->[0m ./tests/snippets/any_err_2.rs:9:9
+  [1m[94m|[0m
+[1m[94m9 |[0m         call()
+  [1m[94m|[0m         [1m[91m^^^^[0m [1m[91mFor this unsafe call.[0m
+  [1m[94m|[0m
+
+[1m[31mTotal counts of diagnostics from safety-tool: {MissingDischarges: 2}[0m
+

--- a/safety-tool/tests/snapshots/any_ok.txt
+++ b/safety-tool/tests/snapshots/any_ok.txt
@@ -1,0 +1,10 @@
+stdout=
+********* "any_ok" [Rlib] has reached 4 instances *********
+"tag_unsafe_fn" ("./tests/snippets/any_ok.rs:24:1: 24:30")
+ => "#[rapx::tag_unsafe_fn(SP1, SP2)]\n"
+
+"call" ("./tests/snippets/any_ok.rs:21:1: 21:17")
+ => "#[rapx::inner(any(SP1, SP2))]\n"
+
+
+stderr=

--- a/safety-tool/tests/snapshots/any_ok_2.txt
+++ b/safety-tool/tests/snapshots/any_ok_2.txt
@@ -1,0 +1,10 @@
+stdout=
+********* "any_ok_2" [Rlib] has reached 4 instances *********
+"tag_unsafe_fn" ("./tests/snippets/any_ok_2.rs:27:1: 27:30")
+ => "#[rapx::tag_unsafe_fn(SP1, SP3)]\n"
+
+"call" ("./tests/snippets/any_ok_2.rs:24:1: 24:17")
+ => "#[rapx::inner(any(SP1, SP2), any { SP3, SP4 })]\n"
+
+
+stderr=

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_assign.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_assign.txt
@@ -1,7 +1,7 @@
 stdout=
 
 stderr=
-[1m[91merror[0m: [1m`Tag` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Tag`[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_assign.rs:12:13
    [1m[94m|[0m
 [1m[94m12 |[0m     let f = call;

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_assign_fn_ptr.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_assign_fn_ptr.txt
@@ -1,7 +1,7 @@
 stdout=
 
 stderr=
-[1m[91merror[0m: [1m`Tag` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Tag`[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_assign_fn_ptr.rs:12:26
    [1m[94m|[0m
 [1m[94m12 |[0m     let f: unsafe fn() = call;

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less.txt
@@ -8,12 +8,5 @@ stderr=
   [1m[94m|[0m [1m[91m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mFor this unsafe call.[0m
   [1m[94m|[0m
 
-[1m[91merror[0m: [1mTag is not discharged: `Align`[0m
-  [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less.rs:10:5
-   [1m[94m|[0m
-[1m[94m10 |[0m     call();
-   [1m[94m|[0m     [1m[91m^^^^[0m [1m[91mFor this unsafe call.[0m
-   [1m[94m|[0m
-
-[1m[31mTotal counts of diagnostics from safety-tool: {MissingDischarges: 2}[0m
+[1m[31mTotal counts of diagnostics from safety-tool: {MissingDischarges: 1}[0m
 

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_discharge_all_tagged_less.txt
@@ -1,14 +1,14 @@
 stdout=
 
 stderr=
-[1m[91merror[0m: [1m`Align` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Align`[0m
  [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less.rs:9:1
   [1m[94m|[0m
 [1m[94m9 |[0m pub unsafe fn tag_unsafe_fn() {
   [1m[94m|[0m [1m[91m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[0m [1m[91mFor this unsafe call.[0m
   [1m[94m|[0m
 
-[1m[91merror[0m: [1m`Align` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Align`[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_discharge_all_tagged_less.rs:10:5
    [1m[94m|[0m
 [1m[94m10 |[0m     call();

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_method.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_method.txt
@@ -1,7 +1,7 @@
 stdout=
 
 stderr=
-[1m[91merror[0m: [1m`Tag` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Tag`[0m
  [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_method.rs:9:9
   [1m[94m|[0m
 [1m[94m9 |[0m         s.call();

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_no_tag.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_no_tag.txt
@@ -1,7 +1,7 @@
 stdout=
 
 stderr=
-[1m[91merror[0m: [1m`Tag` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Tag`[0m
   [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_no_tag.rs:13:9
    [1m[94m|[0m
 [1m[94m13 |[0m         super::call();

--- a/safety-tool/tests/snapshots/unsafe_calls_panic_with_dep.txt
+++ b/safety-tool/tests/snapshots/unsafe_calls_panic_with_dep.txt
@@ -1,7 +1,7 @@
 stdout=
 
 stderr=
-[1m[91merror[0m: [1m`Tag` is not discharged[0m
+[1m[91merror[0m: [1mTag is not discharged: `Tag`[0m
  [1m[94m-->[0m ./tests/snippets/unsafe_calls_panic_with_dep.rs:9:14
   [1m[94m|[0m
 [1m[94m9 |[0m     unsafe { unsafe_calls::tag_unsafe_fn() }

--- a/safety-tool/tests/snippets/any_err.rs
+++ b/safety-tool/tests/snippets/any_err.rs
@@ -1,0 +1,11 @@
+#![feature(stmt_expr_attributes)]
+#![feature(register_tool)]
+#![register_tool(rapx)]
+#![allow(dead_code)]
+
+pub fn tag_expr() {
+    unsafe { call() };
+}
+
+#[rapx::inner(any(SP1, SP2))]
+unsafe fn call() {}

--- a/safety-tool/tests/snippets/any_err_2.rs
+++ b/safety-tool/tests/snippets/any_err_2.rs
@@ -1,0 +1,17 @@
+#![feature(stmt_expr_attributes)]
+#![feature(register_tool)]
+#![register_tool(rapx)]
+#![allow(dead_code)]
+
+pub fn tag_expr() {
+    unsafe {
+        #[rapx::tag_expr(SP1)]
+        call()
+    };
+}
+
+#[rapx::inner(
+    any ( SP1, SP2 ),
+    any { SP3, SP4 }
+)]
+unsafe fn call() {}

--- a/safety-tool/tests/snippets/any_ok.rs
+++ b/safety-tool/tests/snippets/any_ok.rs
@@ -1,0 +1,26 @@
+#![feature(stmt_expr_attributes)]
+#![feature(register_tool)]
+#![register_tool(rapx)]
+#![allow(dead_code)]
+
+pub fn tag_expr() {
+    unsafe {
+        #[rapx::tag_expr(SP1)]
+        call()
+    };
+}
+
+pub fn tag_block() {
+    #[rapx::tag_block(SP2)]
+    unsafe {
+        call();
+    }
+}
+
+#[rapx::inner(any(SP1, SP2))]
+unsafe fn call() {}
+
+#[rapx::tag_unsafe_fn(SP1, SP2)] // not recommended
+pub unsafe fn tag_unsafe_fn() {
+    call();
+}

--- a/safety-tool/tests/snippets/any_ok_2.rs
+++ b/safety-tool/tests/snippets/any_ok_2.rs
@@ -1,0 +1,29 @@
+#![feature(stmt_expr_attributes)]
+#![feature(register_tool)]
+#![register_tool(rapx)]
+#![allow(dead_code)]
+
+pub fn tag_expr() {
+    unsafe {
+        #[rapx::tag_expr(SP1, SP4)]
+        call()
+    };
+}
+
+pub fn tag_block() {
+    #[rapx::tag_block(SP2, SP3)]
+    unsafe {
+        call();
+    }
+}
+
+#[rapx::inner(
+    any ( SP1, SP2 ),
+    any { SP3, SP4 }
+)]
+unsafe fn call() {}
+
+#[rapx::tag_unsafe_fn(SP1, SP3)]
+pub unsafe fn tag_unsafe_fn() {
+    call();
+}

--- a/safety-tool/tests/unsafe_calls.rs
+++ b/safety-tool/tests/unsafe_calls.rs
@@ -120,8 +120,20 @@ fn any_err() {
 }
 
 #[test]
+fn any_err_2() {
+    let [file, outfile] = &testcase("any_err_2");
+    should_panic(file, outfile, Default::default());
+}
+
+#[test]
 fn any_ok() {
     let [file, outfile] = &testcase("any_ok");
+    fine(file, outfile, Default::default());
+}
+
+#[test]
+fn any_ok_2() {
+    let [file, outfile] = &testcase("any_ok_2");
     fine(file, outfile, Default::default());
 }
 

--- a/safety-tool/tests/unsafe_calls.rs
+++ b/safety-tool/tests/unsafe_calls.rs
@@ -113,6 +113,18 @@ fn unsafe_calls_panic_discharge_all_tagged_more() {
     // should_panic(file, outfile, CompilationOptions::discharges_all_properties());
 }
 
+#[test]
+fn any_err() {
+    let [file, outfile] = &testcase("any_err");
+    should_panic(file, outfile, Default::default());
+}
+
+#[test]
+fn any_ok() {
+    let [file, outfile] = &testcase("any_ok");
+    fine(file, outfile, Default::default());
+}
+
 fn fine(file: &str, outfile: &str, opts: CompilationOptions) {
     let (exe, output) = compile(file, opts);
     let stdout = std::str::from_utf8(&output.stdout).unwrap();

--- a/usage.md
+++ b/usage.md
@@ -59,6 +59,21 @@ is addressed as follows:
 unsafe { call() }
 ```
 
+## `any` to discharge at least one SP
+
+`any` tag is a builtin tag that expresses `or` logics in tag definitions on an API, and requires a
+subset of SP arguments to discharge.
+
+```rust
+#[safety { any { Deref(self.ptr, u8, 1), Alive(self.ptr, _) } }] // defsite
+unsafe fn get(&self) {}
+
+#[safety { Deref }] // callsite: at least one of SPs in `any` tag should be discharged
+unsafe { self.get() }
+```
+
+See [PR#48](https://github.com/Artisan-Lab/tag-std/pull/48) for more infomation.
+
 ## RustDoc Generation 
 
 The safety attribute can be automatically expanded into text descriptions once configuration is set.


### PR DESCRIPTION

This PR  closes https://github.com/Artisan-Lab/tag-std/issues/47 , and adjusts discharge diagnostics.

```rust
#[safety { any { Deref(self.ptr, u8, 1), Alive(self.ptr, _) } }] // defsite
unsafe fn get(&self) {}
```

<img width="1194" height="478" alt="" src="https://github.com/user-attachments/assets/f3e86d1c-2352-4839-a3f6-1023303e5d19" />


```rust
#[safety { Deref }] // callsite: at least one of SPs in `any` tag should be discharged
unsafe { self.get() }
```

NOTE: it's possible to have multiple groups of `any` tags, then each group should be properly discharged

```rust
#[safety { // defsite
  any { SP1, SP2 },
  any { SP3, SP4 },
}]
unsafe fn call() {}

#[safety { SP1, SP3 }] // or #[safety { SP1, SP4 }] or something
unsafe { call() }
```

```rust
#[safety { SP1 }] // 💥another group hasn't been discharged
unsafe { call() }

error: Tags are not discharged: `SP3`, or `SP4`
 --> ./tests/snippets/any_err_2.rs:9:9
  |
9 |         call()
  |         ^^^^^^ For this unsafe call.
  |
```