### PR TITLE
Feat: `#[safety]` expands to `#[rapx::proof]` instead of `#[rapx::inner]`

### DIFF
--- a/safety-tool/safety-lib/tests/snapshots/testcase_safety_macro.rs
+++ b/safety-tool/safety-lib/tests/snapshots/testcase_safety_macro.rs
@@ -7,47 +7,47 @@ extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;
 use safety_macro::safety;
-#[rapx::inner(SP)]
+#[rapx::proof(SP)]
 pub unsafe fn vanilla1() {}
-#[rapx::inner(SP1, SP2)]
+#[rapx::proof(SP1, SP2)]
 pub unsafe fn vanilla2() {}
-#[rapx::inner(SP1;SP2)]
+#[rapx::proof(SP1;SP2)]
 pub unsafe fn vanilla3() {}
-#[rapx::inner(SP1:"reason")]
+#[rapx::proof(SP1:"reason")]
 pub unsafe fn sp_with_reason1() {}
-#[rapx::inner(SP1:"reason";SP2:"reason")]
+#[rapx::proof(SP1:"reason";SP2:"reason")]
 pub unsafe fn sp_with_reason2() {}
-#[rapx::inner(SP1, SP2:"reason")]
+#[rapx::proof(SP1, SP2:"reason")]
 pub unsafe fn grouped_sp1() {}
-#[rapx::inner(SP1, SP2:"reason";SP3)]
+#[rapx::proof(SP1, SP2:"reason";SP3)]
 pub unsafe fn grouped_sp2() {}
-#[rapx::inner(SP3;SP1, SP2:"reason")]
+#[rapx::proof(SP3;SP1, SP2:"reason")]
 pub unsafe fn grouped_sp3() {}
-#[rapx::inner(SP3, SP4;SP1, SP2:"reason")]
+#[rapx::proof(SP3, SP4;SP1, SP2:"reason")]
 pub unsafe fn grouped_sp4() {}
-#[rapx::inner(SP3;SP1, SP2:"reason";SP4)]
+#[rapx::proof(SP3;SP1, SP2:"reason";SP4)]
 pub unsafe fn grouped_sp5() {}
-#[rapx::inner(SP1, SP2:"reason";SP3;)]
+#[rapx::proof(SP1, SP2:"reason";SP3;)]
 pub unsafe fn trailing_punct1() {}
-#[rapx::inner(SP1, SP2:"reason";SP3)]
+#[rapx::proof(SP1, SP2:"reason";SP3)]
 pub unsafe fn trailing_punct2() {}
-#[rapx::inner(SP1(a))]
+#[rapx::proof(SP1(a))]
 pub unsafe fn single_sp_with_args1() {}
-#[rapx::inner(SP1(a, b))]
+#[rapx::proof(SP1(a, b))]
 pub unsafe fn single_sp_with_args2() {}
-#[rapx::inner(SP1(a, b, call()))]
+#[rapx::proof(SP1(a, b, call()))]
 pub unsafe fn single_sp_with_args3() {}
-#[rapx::inner(SP1(a), SP2:"reason";SP3)]
+#[rapx::proof(SP1(a), SP2:"reason";SP3)]
 pub unsafe fn multiple_sp_with_args1() {}
-#[rapx::inner(SP(a, b):"reason";SP1, SP2:"reason";SP3, SP4)]
+#[rapx::proof(SP(a, b):"reason";SP1, SP2:"reason";SP3, SP4)]
 pub unsafe fn multiple_sp_with_args2() {}
-#[rapx::inner(hazard.Alias(p, q))]
+#[rapx::proof(hazard.Alias(p, q))]
 pub unsafe fn complex1() {}
-#[rapx::inner(hazard.Alias(A{a:self.a}, a::b(c![])))]
+#[rapx::proof(hazard.Alias(A{a:self.a}, a::b(c![])))]
 pub unsafe fn complex2() {}
-#[rapx::inner(hazard.Alias(A{a:self.a}, a::b(c![])):"")]
+#[rapx::proof(hazard.Alias(A{a:self.a}, a::b(c![])):"")]
 pub unsafe fn complex3() {}
-#[rapx::inner(hazard.Alias(A{a:self.a}, a::b(c![])):"";SP)]
+#[rapx::proof(hazard.Alias(A{a:self.a}, a::b(c![])):"";SP)]
 pub unsafe fn complex4() {}
 #[rustc_main]
 #[coverage(off)]

--- a/safety-tool/safety-macro/src/lib.rs
+++ b/safety-tool/safety-macro/src/lib.rs
@@ -32,7 +32,7 @@ pub fn safety(attr: TokenStream, item: TokenStream) -> TokenStream {
     // add registered tool attr
     let tool_attr = {
         let attr = TokenStream2::from(attr.clone());
-        quote! { #[rapx::inner(#attr)] }
+        quote! { #[rapx::proof(#attr)] }
     };
     ts.extend(tool_attr);
 

--- a/safety-tool/safety-parser/src/lib.rs
+++ b/safety-tool/safety-parser/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(stable_features)]
+// newer toolchain like required by std doesn't need this stablized feature
 #![feature(let_chains)]
 
 pub use proc_macro2;

--- a/safety-tool/src/bin/safety-tool-rfl/main.rs
+++ b/safety-tool/src/bin/safety-tool-rfl/main.rs
@@ -1,7 +1,4 @@
-crossfig::switch! {
-    safety_tool::std => {}
-    _ => { #![feature(let_chains)] }
-}
+#![cfg_attr(not(feature = "std"), feature(let_chains))]
 
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use eyre::Result;

--- a/safety-tool/src/bin/safety-tool-rfl/main.rs
+++ b/safety-tool/src/bin/safety-tool-rfl/main.rs
@@ -1,4 +1,8 @@
-#![feature(let_chains)]
+crossfig::switch! {
+    safety_tool::std => {}
+    _ => { #![feature(let_chains)] }
+}
+
 use cargo_metadata::camino::{Utf8Path, Utf8PathBuf};
 use eyre::Result;
 

--- a/safety-tool/src/bin/safety-tool/analyze_hir/db/data.rs
+++ b/safety-tool/src/bin/safety-tool/analyze_hir/db/data.rs
@@ -63,7 +63,7 @@ impl Data {
     }
 }
 
-fn get_attrs(tcx: TyCtxt, hid: HirId) -> impl Iterator<Item = &Attribute> {
+fn get_attrs(tcx: TyCtxt<'_>, hid: HirId) -> impl Iterator<Item = &'_ Attribute> {
     crossfig::switch! {
         crate::asterinas => {
             tcx.hir_attrs(hid.owner).get(hid.local_id).iter()

--- a/safety-tool/src/bin/safety-tool/main.rs
+++ b/safety-tool/src/bin/safety-tool/main.rs
@@ -1,10 +1,6 @@
 #![feature(rustc_private)]
-
-crossfig::switch! {
-    std => { }
-    asterinas => { #![feature(integer_sign_cast)] }
-    _ => { #![feature(let_chains)] }
-}
+#![cfg_attr(feature = "asterinas", feature(integer_sign_cast))]
+#![cfg_attr(not(feature = "std"), feature(let_chains))]
 
 extern crate itertools;
 extern crate rustc_ast;
@@ -16,8 +12,18 @@ extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate rustc_span;
 
-// Import conditional compilation of feature names. Used in [`crossfig::switch`].
-use safety_tool::{asterinas, std};
+// Conditional compilation of feature names. Used in [`crossfig::switch`].
+// NOTE: before compilation (i.e. calling `cargo build` or something)
+// `./gen_rust_toolchain_toml.rs $proj` should be run first
+// where $proj is one of std, rfl, or asterinas.
+crossfig::alias! {
+    // verify-rust-std
+    std: { #[cfg(feature = "std")] },
+    // Rust for Linux
+    rfl: { #[cfg(feature = "rfl")] },
+    // Asterinas OS
+    asterinas: { #[cfg(feature = "asterinas")] }
+}
 
 crossfig::switch! {
     std => {

--- a/safety-tool/src/bin/safety-tool/main.rs
+++ b/safety-tool/src/bin/safety-tool/main.rs
@@ -1,6 +1,10 @@
 #![feature(rustc_private)]
-#![feature(let_chains)]
-#![cfg_attr(feature = "asterinas", feature(integer_sign_cast))]
+
+crossfig::switch! {
+    std => { }
+    asterinas => { #![feature(integer_sign_cast)] }
+    _ => { #![feature(let_chains)] }
+}
 
 extern crate itertools;
 extern crate rustc_ast;
@@ -12,17 +16,8 @@ extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate rustc_span;
 
-// NOTE: before compilation (i.e. calling `cargo build` or something)
-// `./gen_rust_toolchain_toml.rs $proj` should be run first
-// where $proj is one of std, rfl, or asterinas.
-crossfig::alias! {
-    // verify-rust-std
-    std: { #[cfg(feature = "std")] },
-    // Rust for Linux
-    rfl: { #[cfg(feature = "rfl")] },
-    // Asterinas OS
-    asterinas: { #[cfg(feature = "asterinas")] }
-}
+// Import conditional compilation of feature names. Used in [`crossfig::switch`].
+use safety_tool::{asterinas, std};
 
 crossfig::switch! {
     std => {
@@ -145,7 +140,7 @@ const REGISTER_TOOL: &str = "rapx";
 
 fn is_tool_attr(attr: &rustc_hir::Attribute) -> bool {
     crossfig::switch! {
-        crate::asterinas => {
+        asterinas => {
             if let rustc_hir::AttrKind::Normal(tool_attr) = &attr.kind
                 && tool_attr.path.segments[0].as_str() == REGISTER_TOOL
             {

--- a/safety-tool/src/lib.rs
+++ b/safety-tool/src/lib.rs
@@ -8,15 +8,3 @@ pub use eyre::Result;
 extern crate eyre;
 #[macro_use]
 extern crate tracing;
-
-// NOTE: before compilation (i.e. calling `cargo build` or something)
-// `./gen_rust_toolchain_toml.rs $proj` should be run first
-// where $proj is one of std, rfl, or asterinas.
-crossfig::alias! {
-    // verify-rust-std
-    pub std: { #[cfg(feature = "std")] },
-    // Rust for Linux
-    pub rfl: { #[cfg(feature = "rfl")] },
-    // Asterinas OS
-    pub asterinas: { #[cfg(feature = "asterinas")] }
-}

--- a/safety-tool/src/lib.rs
+++ b/safety-tool/src/lib.rs
@@ -8,3 +8,15 @@ pub use eyre::Result;
 extern crate eyre;
 #[macro_use]
 extern crate tracing;
+
+// NOTE: before compilation (i.e. calling `cargo build` or something)
+// `./gen_rust_toolchain_toml.rs $proj` should be run first
+// where $proj is one of std, rfl, or asterinas.
+crossfig::alias! {
+    // verify-rust-std
+    pub std: { #[cfg(feature = "std")] },
+    // Rust for Linux
+    pub rfl: { #[cfg(feature = "rfl")] },
+    // Asterinas OS
+    pub asterinas: { #[cfg(feature = "asterinas")] }
+}

--- a/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
+++ b/safety-tool/tests/basic/macro-expanded/cargo-safety-tool.txt
@@ -25,12 +25,12 @@
 ********* "safety_macro" [ProcMacro] has reached 161 instances *********
 ********* "demo" [Rlib] has reached 8 instances *********
 "test" ("src/lib.rs:9:1: 9:26")
- => "#[rapx::inner(Unreachable)]\n"
+ => "#[rapx::proof(Unreachable)]\n"
 
 "MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any\n{ Deref(self.ptr, u8, 1), Alive(self.ptr, _) })]\n"
+ => "#[rapx::proof(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any\n{ Deref(self.ptr, u8, 1), Alive(self.ptr, _) })]\n"
 
 ********* "demo" [Executable] has reached 18 instances *********
 "demo::MyStruct::get" ("src/lib.rs:31:5: 31:42")
- => "#[rapx::inner(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any\n{ Deref(self.ptr, u8, 1), Alive(self.ptr, _) })]\n"
+ => "#[rapx::proof(Init(self.ptr, u8, self.len), InBound(self.ptr, u8, self.len),\nValidNum(self.len*sizeof(u8), [0,isize::MAX]), Alias(self.ptr),\nRustdocLinkToItem(\"crate::test\"), any\n{ Deref(self.ptr, u8, 1), Alive(self.ptr, _) })]\n"
 

--- a/safety-tool/tests/basic/macro-expanded/lib.rs
+++ b/safety-tool/tests/basic/macro-expanded/lib.rs
@@ -8,7 +8,7 @@ extern crate std;
 #[prelude_import]
 use std::prelude::rust_2024::*;
 use safety_macro::safety;
-#[rapx::inner(Unreachable)]
+#[rapx::proof(Unreachable)]
 /**# Safety
 
 */
@@ -24,7 +24,7 @@ impl MyStruct {
     pub fn from(p: *mut u8, l: usize) -> MyStruct {
         MyStruct { ptr: p, len: l }
     }
-    #[rapx::inner(
+    #[rapx::proof(
         Init(self.ptr, u8, self.len),
         InBound(self.ptr, u8, self.len),
         ValidNum(self.len*sizeof(u8), [0, isize::MAX]),

--- a/safety-tool/tests/basic/macro-expanded/main.rs
+++ b/safety-tool/tests/basic/macro-expanded/main.rs
@@ -13,7 +13,7 @@ use safety_macro::safety;
 fn main() {
     let (p, l, _c) = Vec::new().into_raw_parts();
     let a = MyStruct::from(p, l);
-    #[rapx::inner(
+    #[rapx::proof(
         Init:"This is from a valid Vec object.";InBound:"This is from a valid Vec object.";ValidNum:"self.len is valid.";Alias:"p is no longer used.";RustdocLinkToItem,
         Alive
     )]


### PR DESCRIPTION
This PR
* replaces expanded `rapx::inner` with `rapx::proof` to agree with `#[kanitool::proof]`
* fix warnings of stablized features on newer toolchains