### PR TITLE
Feat: support `safety-lsp.env.SAFETY_LSP` for remote vscode LSP

### DIFF
--- a/safety-tool/safety-lsp/README.md
+++ b/safety-tool/safety-lsp/README.md
@@ -6,7 +6,7 @@
 
 ## Configuration for VSCode
 
-* For `.vscode/settings.json`, `SP_FILE` starts from workspace root if it's a relative path:
+1. For `.vscode/settings.json`, `SP_FILE` starts from workspace root if it's a relative path:
 
 ```json
 {
@@ -20,7 +20,18 @@
 
 `SP_DIR` is also supported, but only one of them should be specified.
 
-* `Ctrl+Space` to open hover doc panel of each completion candidate if the doc is not shown.
+2. For remote usage, `safety-lsp.env.SAFETY_LSP` should be set as vscode will fail to find
+  `safety-lsp` due to absence of bash env loading.
+
+```json
+{
+  "safety-tool.env": {
+    "SAFETY_LSP": "/path/to/safety-lsp"
+  }
+}
+```
+
+3. `Ctrl+Space` to open hover doc panel of each completion candidate if the doc is not shown.
 
 ## Configuration for Neovim
 

--- a/safety-tool/safety-lsp/vscode-plugin/client/src/extension.ts
+++ b/safety-tool/safety-lsp/vscode-plugin/client/src/extension.ts
@@ -21,11 +21,13 @@ export function activate(_context: ExtensionContext) {
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
 
   const run: Executable = {
-    command: "safety-lsp",
+    // `safety-lsp.env.SAFETY_LSP` can be set in .vscode/settings.json to point to a specific binary
+    command: extraEnv["SAFETY_LSP"] ?? "safety-lsp",
     options: {
       // Run safety-lsp under the first workspace root
       cwd: workspaceRoot,
-      // `SP_FILE` can be set in .vscode/settings.json to point to a spec TOML path starting from the workspace root
+      // `safety-lsp.env.SP_FILE` can be set in .vscode/settings.json to 
+      // point to a tag specification TOML path starting from the workspace root
       env: { SP_DISABLE_CHECK: 1, ...extraEnv },
     },
   };

--- a/safety-tool/safety-lsp/vscode-plugin/client/src/extension.ts
+++ b/safety-tool/safety-lsp/vscode-plugin/client/src/extension.ts
@@ -21,12 +21,13 @@ export function activate(_context: ExtensionContext) {
   const workspaceRoot = workspace.workspaceFolders?.[0]?.uri.fsPath;
 
   const run: Executable = {
-    // `safety-lsp.env.SAFETY_LSP` can be set in .vscode/settings.json to point to a specific binary
+    // `safety-lsp.env.SAFETY_LSP` can be set in .vscode/settings.json to point to a specific binary.
+    // For remote usage, this should be set as bash env is not loaded and safety-lsp is not in scope.
     command: extraEnv["SAFETY_LSP"] ?? "safety-lsp",
     options: {
       // Run safety-lsp under the first workspace root
       cwd: workspaceRoot,
-      // `safety-lsp.env.SP_FILE` can be set in .vscode/settings.json to 
+      // `safety-lsp.env.SP_FILE` can be set in .vscode/settings.json to
       // point to a tag specification TOML path starting from the workspace root
       env: { SP_DISABLE_CHECK: 1, ...extraEnv },
     },


### PR DESCRIPTION
For remote usage, `safety-lsp.env.SAFETY_LSP` should be set as vscode will fail to find   `safety-lsp` due to absence of bash env loading.

```json
{
  "safety-tool.env": {
    "SAFETY_LSP": "/path/to/safety-lsp"
  }
}
```
